### PR TITLE
Implement view routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ npm install @jetkit/cdk
 ```typescript
 import { HttpMethod } from "@aws-cdk/aws-apigatewayv2"
 import { badRequest, methodNotAllowed } from "@jdpnielsen/http-error"
-import { ApiEvent, ApiResponse, ApiViewBase, apiViewHandler } from "../api/base"
-import { ApiView, Route, SubRoute } from "@jetkit/cdk"
+import { ApiView, Route, SubRoute, ApiEvent, ApiResponse, ApiViewBase, apiViewHandler } from "@jetkit/cdk"
 
 @ApiView({
   path: "/album",

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ and generating cloud infrastructure using [AWS CDK](https://docs.aws.amazon.com/
 We want to build maintainable and scalable cloud-first applications, with cloud resources generated from application code.
 
 Using AWS CDK we can automate generating API Gateway routes and Lambda functions from class and function metadata.
-Each class or function view is a self-contained Lambda function that only pulls in the dependencies needed for its functioning, keeping startup times low and applications modular.
-Get all of the power of a minimal web framework without cramming your entire app into a single Lambda.
+Each class or function view is a self-contained Lambda function that only pulls in the dependencies needed for its
+functioning, keeping startup times low and applications modular.
+Get the utility of a minimal web framework without cramming your entire app into a single Lambda.
 
 Optional support for TypeORM using the Aurora Serverless Data API and convenient helpers for CRUD, serialization, tracing, and error handling will be added soon.
 
@@ -38,12 +39,11 @@ npm install @jetkit/cdk
 import { HttpMethod } from "@aws-cdk/aws-apigatewayv2"
 import { badRequest, methodNotAllowed } from "@jdpnielsen/http-error"
 import { APIGatewayProxyHandlerV2 } from "aws-lambda"
-import { APIEvent, ApiViewBase, RequestHandler } from "../api/base"
-import { ApiView, Route, SubRoute } from "../registry"
+import { APIEvent, ApiViewBase, RequestHandler, apiViewHandler, ApiView, Route, SubRoute } from "@jetkit/cdk"
 
+// define optional properties for our functions
 const lambdaOpts = {
   memorySize: 512,
-  entry: __filename,
   bundling: {
     minify: true,
     sourceMap: true,
@@ -54,10 +54,14 @@ const lambdaOpts = {
 }
 
 @ApiView({
+  // base route
   path: "/album",
   ...lambdaOpts,
 })
 export class AlbumApi extends ApiViewBase {
+  // define POST handler
+  post: APIGatewayProxyHandlerV2 = async () => "Created new album"
+
   // custom endpoint in the view
   // routes to the ApiView function
   @SubRoute({
@@ -76,12 +80,10 @@ export class AlbumApi extends ApiViewBase {
     else if (method == HttpMethod.DELETE) return `Unliked album ${albumId}`
     else return methodNotAllowed()
   }
-
-  // define POST handler
-  post: APIGatewayProxyHandlerV2 = async () => "Created new album"
 }
 
-export const handler: RequestHandler = async (event, context) => new AlbumApi().dispatch(event, context)
+// entry point for the file
+export const handler = apiViewHandler(__filename, TopicCrudApi)
 ```
 
 ### Handler Function With Route

--- a/README.md
+++ b/README.md
@@ -38,29 +38,20 @@ npm install @jetkit/cdk
 ```typescript
 import { HttpMethod } from "@aws-cdk/aws-apigatewayv2"
 import { badRequest, methodNotAllowed } from "@jdpnielsen/http-error"
-import { APIGatewayProxyHandlerV2 } from "aws-lambda"
-import { APIEvent, ApiViewBase, RequestHandler, apiViewHandler, ApiView, Route, SubRoute } from "@jetkit/cdk"
+import { ApiEvent, ApiResponse, ApiViewBase, apiViewHandler } from "../api/base"
+import { ApiView, Route, SubRoute } from "@jetkit/cdk"
 
-// define optional properties for our functions
-const lambdaOpts = {
+@ApiView({
+  path: "/album",
   memorySize: 512,
-  bundling: {
-    minify: true,
-    sourceMap: true,
-  },
   environment: {
     LOG_LEVEL: "DEBUG",
   },
-}
-
-@ApiView({
-  // base route
-  path: "/album",
-  ...lambdaOpts,
+  bundling: { minify: true, metafile: true, sourceMap: true },
 })
 export class AlbumApi extends ApiViewBase {
   // define POST handler
-  post: APIGatewayProxyHandlerV2 = async () => "Created new album"
+  post = async () => "Created new album"
 
   // custom endpoint in the view
   // routes to the ApiView function
@@ -68,7 +59,7 @@ export class AlbumApi extends ApiViewBase {
     path: "/{albumId}/like", // will be /album/123/like
     methods: [HttpMethod.POST, HttpMethod.DELETE],
   })
-  async like(event: APIEvent) {
+  async like(event: ApiEvent): ApiResponse {
     const albumId = event.pathParameters?.albumId
     if (!albumId) throw badRequest("albumId is required in path")
 
@@ -81,9 +72,7 @@ export class AlbumApi extends ApiViewBase {
     else return methodNotAllowed()
   }
 }
-
-// entry point for the file
-export const handler = apiViewHandler(__filename, TopicCrudApi)
+export const handler = apiViewHandler(__filename, AlbumApi)
 ```
 
 ### Handler Function With Route

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ export class AlbumApi extends ApiViewBase {
     if (method == HttpMethod.POST) return `Liked album ${albumId}`
     // DELETE - unmark album as liked
     else if (method == HttpMethod.DELETE) return `Unliked album ${albumId}`
+    // should never be reached
     else return methodNotAllowed()
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jetkit/cdk",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@jetkit/cdk",
-      "version": "0.0.31",
+      "version": "0.0.32",
       "license": "MIT",
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2": "^1.100.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jetkit/cdk",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@jetkit/cdk",
-      "version": "0.0.32",
+      "version": "0.0.33",
       "license": "MIT",
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2": "^1.100.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jetkit/cdk",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@jetkit/cdk",
-      "version": "0.0.33",
+      "version": "0.0.34",
       "license": "MIT",
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2": "^1.100.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jetkit/cdk",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@jetkit/cdk",
-      "version": "0.0.28",
+      "version": "0.0.31",
       "license": "MIT",
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2": "^1.100.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetkit/cdk",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "Cloud-native serverless development mini-framework",
   "types": "build/esm/index.d.ts",
   "main": "build/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetkit/cdk",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "Cloud-native serverless development mini-framework",
   "types": "build/esm/index.d.ts",
   "main": "build/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetkit/cdk",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "description": "Cloud-native serverless development mini-framework",
   "types": "build/esm/index.d.ts",
   "main": "build/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetkit/cdk",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "description": "Cloud-native serverless development mini-framework",
   "types": "build/esm/index.d.ts",
   "main": "build/cjs/index.js",

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -135,7 +135,7 @@ export class ApiViewBase {
     let method = event.requestContext.http.method as HttpMethod
 
     // route key matches base route?
-    if (!this.matchesRouteKey(routeKey, method, viewMeta.path, viewMeta.methods)) return undefined
+    if (!this.matchesRouteKey(routeKey, method, viewMeta.path, viewMeta.methods, false)) return undefined
 
     // look up handler based on HTTP verb e.g. this.post()
     method = method.toLowerCase() as HttpMethod
@@ -165,7 +165,13 @@ export class ApiViewBase {
     return undefined
   }
 
-  protected matchesRouteKey(routeKey: string, method: HttpMethod, path: string, methods?: HttpMethod[]): boolean {
+  protected matchesRouteKey(
+    routeKey: string,
+    method: HttpMethod,
+    path: string,
+    methods?: HttpMethod[],
+    canMatchAnyMethod = true
+  ): boolean {
     const matchAnyMethod = !methods || methods.includes(HttpMethod.ANY)
     method = method.toUpperCase() as HttpMethod
 
@@ -180,7 +186,7 @@ export class ApiViewBase {
     if (matchRouteKey === routeKey) return true
 
     // special case - ANY
-    if (matchAnyMethod && matchAnyRouteKey == `${HttpMethod.ANY} ${path}`) return true
+    if (canMatchAnyMethod && matchAnyMethod && matchAnyRouteKey == `${HttpMethod.ANY} ${path}`) return true
 
     return false
   }
@@ -206,7 +212,7 @@ export class ApiViewBase {
         return await handlerMethod(event, context)
       } else {
         // 404
-        throw notFound(`The path ${path} was not found`)
+        throw notFound(`The path ${method} ${path} was not found`)
       }
     } catch (ex) {
       // exception raised

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -138,13 +138,13 @@ export class ApiViewBase {
 
     // routeKey to match e.g. "POST /album/{albumId}/like"
     const matchRouteKey = `${method} ${path}`
-    const matchAnyRouteKey = matchRouteKey.replace(method, HttpMethod.ANY)
+    const matchAnyRouteKey = `${HttpMethod.ANY} ${path}`
 
     // route key match?
     if (matchRouteKey === routeKey) return true
 
     // special case - ANY
-    if (matchAnyMethod && matchAnyRouteKey == `${HttpMethod.ANY} ${routeKey}`) return true
+    if (matchAnyMethod && matchAnyRouteKey === routeKey) return true
 
     return false
   }

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -54,44 +54,11 @@ async function raiseNotAllowed(event: ApiEvent) {
 /**
  * A view with method-based routing.
  *
- * Subclass APIView to define your own class-based API endpoints.
+ * Subclass {@link ApiViewBase} to define your own class-based API endpoints.
  *
- * Methods with HTTP verb names (get, post, patch, etc) are called.
- * Define custom sub-paths with @SubRoute().
+ * Methods with HTTP verb names (get, post, patch, etc) are called automatically.
+ * Define custom sub-paths with {@link SubRoute}.
  *
- * @example
- * ```typescript
- * @ApiView({
- *   path: "/album",
- *   memorySize: 512,
- *   environment: {
- *     LOG_LEVEL: "DEBUG",
- *   },
- * })
- * export class AlbumApi extends ApiViewBase {
- *   // custom endpoint in the view
- *   @SubRoute({
- *     path: "/{albumId}/like",  // will be /album/123/like
- *     methods: [HttpMethod.POST, HttpMethod.DELETE],
- *   })
- *   async like(event: ApiEvent) {
- *     const albumId = event.pathParameters?.albumId
- *     if (!albumId) throw badRequest("albumId is required in path")
- *
- *     const method = event.requestContext.http.method
- *
- *     // POST - mark album as liked
- *     if (method == HttpMethod.POST) return `Liked album ${albumId}`
- *     // DELETE - unmark album as liked
- *     else if (method == HttpMethod.DELETE) return `Unliked album ${albumId}`
- *     else return methodNotAllowed()
- *   }
- *
- *   // define POST handler
- *   post: RequestHandler = async () => "Created new album"
- * }
- * export const handler = apiViewHandler(__filename, AlbumApi)
- * ```
  */
 export class ApiViewBase {
   get: RequestHandler = async (event) => raiseNotAllowed(event)

--- a/src/cdk/api/api.ts
+++ b/src/cdk/api/api.ts
@@ -1,13 +1,15 @@
 import { HttpApi, HttpMethod, PayloadFormatVersion } from "@aws-cdk/aws-apigatewayv2"
 import { LambdaProxyIntegration } from "@aws-cdk/aws-apigatewayv2-integrations"
-import { NodejsFunction, NodejsFunctionProps } from "@aws-cdk/aws-lambda-nodejs"
+import { NodejsFunctionProps } from "@aws-cdk/aws-lambda-nodejs"
 import { Construct } from "@aws-cdk/core"
 import { Node14Func } from "../lambda/node14func"
 
 /**
  * @category Construct
  */
-export interface ApiProps extends NodejsFunctionProps {
+export interface ApiProps extends NodejsFunctionProps, IEndpoint {}
+
+export interface IEndpoint {
   /**
    * API Gateway HTTP API
    */
@@ -18,7 +20,24 @@ export interface ApiProps extends NodejsFunctionProps {
    */
   path?: string
 
+  /**
+   * Enabled {@link HttpMethod}s for route
+   */
   methods?: HttpMethod[]
+}
+
+export interface IAddRoutes extends IEndpoint {
+  lambdaApiIntegration: LambdaProxyIntegration
+}
+export abstract class ApiViewMixin extends Construct {
+  addRoutes({ methods, path = "/", httpApi, lambdaApiIntegration }: IAddRoutes) {
+    // * /path -> lambda integration
+    httpApi.addRoutes({
+      path,
+      methods: methods || [HttpMethod.ANY],
+      integration: lambdaApiIntegration,
+    })
+  }
 }
 
 /**
@@ -28,12 +47,13 @@ export interface ApiProps extends NodejsFunctionProps {
  *
  * @category Construct
  */
-export class ApiView extends Construct {
-  handlerFunction: NodejsFunction
-  lambdaApiIntegration: LambdaProxyIntegration
+export class ApiView extends ApiViewMixin implements IEndpoint {
+  handlerFunction: Node14Func
   httpApi: HttpApi
-  path: string
+  path?: string
   methods?: HttpMethod[]
+
+  lambdaApiIntegration: LambdaProxyIntegration
 
   constructor(scope: Construct, id: string, { httpApi, methods, path = "/", ...rest }: ApiProps) {
     super(scope, id)
@@ -51,15 +71,6 @@ export class ApiView extends Construct {
     this.path = path
     this.methods = methods
 
-    this.addRoutes()
-  }
-
-  private addRoutes() {
-    // * /path -> lambda integration
-    this.httpApi.addRoutes({
-      path: this.path,
-      methods: this.methods || [HttpMethod.ANY],
-      integration: this.lambdaApiIntegration,
-    })
+    this.addRoutes({ httpApi, methods, path, lambdaApiIntegration: this.lambdaApiIntegration })
   }
 }

--- a/src/cdk/api/api.ts
+++ b/src/cdk/api/api.ts
@@ -59,7 +59,7 @@ export class ApiView extends ApiViewMixin implements IEndpoint {
     super(scope, id)
 
     // lambda handler
-    this.handlerFunction = new Node14Func(this, `Api${id}`, rest)
+    this.handlerFunction = new Node14Func(this, `View${id}`, rest)
 
     // lambda API integration
     this.lambdaApiIntegration = new LambdaProxyIntegration({

--- a/src/cdk/api/api.ts
+++ b/src/cdk/api/api.ts
@@ -48,11 +48,11 @@ export abstract class ApiViewMixin extends Construct {
  * @category Construct
  */
 export class ApiView extends ApiViewMixin implements IEndpoint {
-  handlerFunction: Node14Func
   httpApi: HttpApi
   path?: string
   methods?: HttpMethod[]
 
+  handlerFunction: Node14Func
   lambdaApiIntegration: LambdaProxyIntegration
 
   constructor(scope: Construct, id: string, { httpApi, methods, path = "/", ...rest }: ApiProps) {

--- a/src/cdk/api/subRoute.ts
+++ b/src/cdk/api/subRoute.ts
@@ -1,9 +1,7 @@
-import { HttpMethod } from "@aws-cdk/aws-apigatewayv2"
 import { Construct } from "@aws-cdk/core"
-import { ApiView } from "./api"
+import { ApiView, ApiViewMixin, IEndpoint } from "./api"
 
-export interface ISubRouteApiProps {
-  methods?: HttpMethod[]
+export interface ISubRouteApiProps extends Omit<IEndpoint, "httpApi"> {
   parentApi: ApiView
   path: string
 }
@@ -13,7 +11,7 @@ export interface ISubRouteApiProps {
  *
  * @category Construct
  */
-export class SubRouteApi extends Construct {
+export class SubRouteApi extends ApiViewMixin {
   constructor(scope: Construct, id: string, { methods, parentApi, path }: ISubRouteApiProps) {
     super(scope, id)
 
@@ -23,10 +21,11 @@ export class SubRouteApi extends Construct {
 
     // add our route to the existing parent API's handler function
     // it will know how to find our method and call it
-    parentApi.httpApi.addRoutes({
+    this.addRoutes({
       path,
-      methods: methods || [HttpMethod.ANY],
-      integration: parentApi.lambdaApiIntegration,
+      methods,
+      httpApi: parentApi.httpApi,
+      lambdaApiIntegration: parentApi.lambdaApiIntegration,
     })
   }
 }

--- a/src/cdk/lambda/node14func.ts
+++ b/src/cdk/lambda/node14func.ts
@@ -11,7 +11,7 @@ export type Node14FuncProps = NodejsFunctionProps
  */
 export class Node14Func extends NodejsFunction {
   constructor(scope: Construct, id: string, props: Node14FuncProps) {
-    let { environment, runtime, awsSdkConnectionReuse, ...rest } = props
+    let { environment, runtime, awsSdkConnectionReuse, bundling, ...rest } = props
 
     // default to source maps enabled
     environment ||= {}
@@ -23,11 +23,19 @@ export class Node14Func extends NodejsFunction {
     // https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/node-reusing-connections.html
     if (typeof awsSdkConnectionReuse === "undefined") awsSdkConnectionReuse = true
 
+    bundling ||= {}
+    let { keepNames, ...bundlingRest } = bundling
+    if (typeof keepNames == "undefined") keepNames = true
+
     const newProps = {
       ...rest,
       awsSdkConnectionReuse,
       environment,
       runtime,
+      bundling: {
+        keepNames,
+        bundlingRest,
+      },
     }
 
     super(scope, id, newProps)

--- a/src/cdk/lambda/node14func.ts
+++ b/src/cdk/lambda/node14func.ts
@@ -7,13 +7,16 @@ import { Runtime } from "@aws-cdk/aws-lambda"
 export type Node14FuncProps = NodejsFunctionProps
 
 /**
+ * Lambda function with agreeable defaults.
+ *
  * @category Construct
  */
 export class Node14Func extends NodejsFunction {
   constructor(scope: Construct, id: string, props: Node14FuncProps) {
     let { environment, runtime, awsSdkConnectionReuse, bundling, ...rest } = props
 
-    // default to source maps enabled
+    // default to source map support in node enabled
+    // makes your stack traces look nicer if sourceMap is turned on
     environment ||= {}
     if (!environment.NODE_OPTIONS) environment.NODE_OPTIONS = "--enable-source-maps"
 
@@ -23,6 +26,8 @@ export class Node14Func extends NodejsFunction {
     // https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/node-reusing-connections.html
     if (typeof awsSdkConnectionReuse === "undefined") awsSdkConnectionReuse = true
 
+    // we should preserve function names for introspection
+    // https://esbuild.github.io/api/#keep-names
     bundling ||= {}
     let { keepNames, ...bundlingRest } = bundling
     if (typeof keepNames == "undefined") keepNames = true

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export { CrudApiViewBase } from "./api/crud/base"
 export { ApiViewBase, ApiEvent, ApiResponse, RequestHandler, apiViewHandler } from "./api/base"
 
 // metadata
-export { ApiView, Route, SubRoute, IRouteProps } from "./registry"
+export { ApiView, Route, SubRoute, IRouteProps, ISubRouteProps } from "./registry"
 export {
   IApiMetadata,
   IApiViewClassMetadata,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ export { JetKitCdkApp } from "./app/cdk"
 // cdk
 export { CrudApi as CrudApiConstruct } from "./cdk/api/crud"
 export { ApiView as ApiViewConstruct, ApiProps as ApiViewConstructProps } from "./cdk/api/api"
-export { ResourceGenerator as ResourceGeneratorConstruct } from "./cdk/generator"
+export { ResourceGenerator as ResourceGeneratorConstruct, ResourceGeneratorProps } from "./cdk/generator"
 
 // convient CDK utilities to have
 export { CorsHttpMethod } from "@aws-cdk/aws-apigatewayv2"

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export { Duration } from "@aws-cdk/core"
 
 // api
 export { CrudApiViewBase } from "./api/crud/base"
-export { ApiViewBase, APIEvent, RequestHandler, apiViewHandler } from "./api/base"
+export { ApiViewBase, ApiEvent, ApiResponse, RequestHandler, apiViewHandler } from "./api/base"
 
 // metadata
 export { ApiView, Route, SubRoute, IRouteProps } from "./registry"
@@ -27,3 +27,6 @@ export {
 
 // database
 export { BaseModel } from "./database/baseModel"
+
+// sample app
+export { AlbumApi, topSongsHandler } from "./test/sampleApp"

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -31,6 +31,7 @@ import { findDefiningFile } from "./util/function"
  * @category Metadata Decorator
  */
 export function ApiView(opts: IApiMetadata) {
+  // try to guess the filename where this decorator is being applied
   if (!opts.entry) opts.entry = guessEntrypoint("ApiView")
 
   // return decorator
@@ -150,22 +151,20 @@ export function Route(props: IRouteProps) {
  * Search call stack for a function with a given name.
  * Not reliable for decorators.
  *
- * @param functionName callsite function name.
- * @returns path where function callsite was found.
+ * @param functionName callsite function name
+ * @returns path where function callsite was found
  *
  */
-function guessEntrypoint(functionName: string | null): string {
+function guessEntrypoint(functionName: string | null): string | undefined {
   // guess entrypoint file from caller
-  let guessedEntry
-  try {
-    guessedEntry = findDefiningFile(functionName)
-  } catch (ex) {
-    console.error(ex)
+  const guessedEntry = findDefiningFile(functionName)
+
+  if (!guessedEntry || !fs.existsSync(guessedEntry)) {
+    // throw new Error(
+    //   `Could not determine entry point where ${functionName} was called, please define path to entrypoint file in "entry"`
+    // )
+    return undefined
   }
 
-  if (!guessedEntry || !fs.existsSync(guessedEntry))
-    throw new Error(
-      `Could not determine entry point where ${functionName} was called, please define path to entrypoint file in "entry"`
-    )
   return guessedEntry
 }

--- a/src/test/api/view.spec.ts
+++ b/src/test/api/view.spec.ts
@@ -1,0 +1,100 @@
+import { HttpMethod } from "@aws-cdk/aws-apigatewayv2"
+import { ApiEvent, ApiViewBase } from "../../api/base"
+import { ApiView, SubRoute } from "../../registry"
+import { AlbumApi } from "../sampleApp"
+
+interface IMakeApiEvent {
+  method: HttpMethod
+  path?: string
+  routeKey: string
+}
+function makeApiEvent({ method, routeKey, path = "/" }: IMakeApiEvent): Partial<ApiEvent> {
+  return {
+    requestContext: {
+      accountId: "foo",
+      apiId: "bar",
+      domainName: "baz",
+      domainPrefix: "blargle",
+      http: {
+        method,
+        path,
+        protocol: "https",
+        sourceIp: "127.0.0.1",
+        userAgent: "Konqueror",
+      },
+      requestId: "a",
+      routeKey: `${method.toUpperCase()} ${routeKey}`,
+      stage: "prod",
+      time: "abc",
+      timeEpoch: 123,
+    },
+    routeKey: `${method.toUpperCase()} ${routeKey}`,
+  }
+}
+
+describe("ApiViewBase", () => {
+  const view = new AlbumApi()
+
+  describe("findHandler", () => {
+    it("locates handler method based on request verb", () => {
+      const request = makeApiEvent({
+        method: HttpMethod.POST,
+        path: "/album",
+        routeKey: "/album",
+      })
+
+      expect(view.findHandler(request as ApiEvent)).toEqual(AlbumApi.prototype.post)
+    })
+
+    it("locates appropriate method based on request", () => {
+      const request = makeApiEvent({
+        method: HttpMethod.POST,
+        path: "/album/123/like",
+        routeKey: "/album/{albumId}/like",
+      })
+
+      expect(view.findHandler(request as ApiEvent)).toEqual(AlbumApi.prototype.like)
+    })
+
+    it("locates appropriate method with ANY verb", () => {
+      @ApiView({
+        path: "/proxy",
+      })
+      class AnyApi extends ApiViewBase {
+        @SubRoute({ path: "/sub", methods: [HttpMethod.ANY] })
+        async handler() {
+          return "OK"
+        }
+      }
+
+      const request = makeApiEvent({
+        method: HttpMethod.POST,
+        path: "/proxy",
+        routeKey: "/sub",
+      })
+
+      const anyView = new AnyApi()
+      expect(anyView.findHandler(request as ApiEvent)).toEqual(AnyApi.prototype.handler)
+    })
+
+    it("locates no method based on request if no match on routeKey", () => {
+      const request = makeApiEvent({
+        method: HttpMethod.POST,
+        path: "/album/123/like",
+        routeKey: "/album/x/{albumId}/like",
+      })
+
+      expect(view.findHandler(request as ApiEvent)).toBeUndefined()
+    })
+
+    it("locates no method based on request if no match on method", () => {
+      const request = makeApiEvent({
+        method: HttpMethod.HEAD,
+        path: "/album/123/like",
+        routeKey: "/album/{albumId}/like",
+      })
+
+      expect(view.findHandler(request as ApiEvent)).toBeUndefined()
+    })
+  })
+})

--- a/src/test/api/view.spec.ts
+++ b/src/test/api/view.spec.ts
@@ -70,11 +70,27 @@ describe("ApiViewBase", () => {
       const request = makeApiEvent({
         method: HttpMethod.POST,
         path: "/proxy",
-        routeKey: "/sub",
+        routeKey: "/proxy/sub",
       })
 
       const anyView = new AnyApi()
-      expect(anyView.findHandler(request as ApiEvent)).toEqual(AnyApi.prototype.handler)
+      expect(anyView.findHandler(request as ApiEvent)).toEqual(anyView.handler)
+    })
+
+    it("locates appropriate class route with any method", () => {
+      @ApiView({
+        path: "/proxy",
+      })
+      class AnyApi extends ApiViewBase {}
+
+      const request = makeApiEvent({
+        method: HttpMethod.POST,
+        path: "/proxy",
+        routeKey: "/proxy",
+      })
+
+      const anyView = new AnyApi()
+      expect(anyView.findHandler(request as ApiEvent)).toEqual(anyView.post)
     })
 
     it("locates no method based on request if no match on routeKey", () => {

--- a/src/test/api/view.spec.ts
+++ b/src/test/api/view.spec.ts
@@ -43,7 +43,7 @@ describe("ApiViewBase", () => {
         routeKey: "/album",
       })
 
-      expect(view.findHandler(request as ApiEvent)).toEqual(AlbumApi.prototype.post)
+      expect(view.findHandler(request as ApiEvent)).toEqual(view.post)
     })
 
     it("locates appropriate method based on request", () => {
@@ -53,7 +53,7 @@ describe("ApiViewBase", () => {
         routeKey: "/album/{albumId}/like",
       })
 
-      expect(view.findHandler(request as ApiEvent)).toEqual(AlbumApi.prototype.like)
+      expect(view.findHandler(request as ApiEvent)).toEqual(view.like)
     })
 
     it("locates appropriate method with ANY verb", () => {

--- a/src/test/api/view.spec.ts
+++ b/src/test/api/view.spec.ts
@@ -69,7 +69,7 @@ describe("ApiViewBase", () => {
 
       const request = makeApiEvent({
         method: HttpMethod.POST,
-        path: "/proxy",
+        path: "/proxy/sub",
         routeKey: "/proxy/sub",
       })
 

--- a/src/test/sampleApp.ts
+++ b/src/test/sampleApp.ts
@@ -1,6 +1,5 @@
 import { HttpMethod } from "@aws-cdk/aws-apigatewayv2"
 import { badRequest, methodNotAllowed } from "@jdpnielsen/http-error"
-import { APIGatewayProxyHandlerV2 } from "aws-lambda"
 import { ApiEvent, ApiResponse, ApiViewBase, apiViewHandler } from "../api/base"
 import { ApiView, Route, SubRoute } from "../registry"
 
@@ -14,7 +13,7 @@ import { ApiView, Route, SubRoute } from "../registry"
 })
 export class AlbumApi extends ApiViewBase {
   // define POST handler
-  post: APIGatewayProxyHandlerV2 = async () => "Created new album"
+  post = async () => "Created new album"
 
   // custom endpoint in the view
   // routes to the ApiView function

--- a/src/test/sampleApp.ts
+++ b/src/test/sampleApp.ts
@@ -1,7 +1,7 @@
 import { HttpMethod } from "@aws-cdk/aws-apigatewayv2"
 import { badRequest, methodNotAllowed } from "@jdpnielsen/http-error"
 import { APIGatewayProxyHandlerV2 } from "aws-lambda"
-import { APIEvent, ApiViewBase, RequestHandler } from "../api/base"
+import { ApiEvent, ApiResponse, ApiViewBase, apiViewHandler } from "../api/base"
 import { ApiView, Route, SubRoute } from "../registry"
 
 @ApiView({
@@ -22,7 +22,7 @@ export class AlbumApi extends ApiViewBase {
     path: "/{albumId}/like", // will be /album/123/like
     methods: [HttpMethod.POST, HttpMethod.DELETE],
   })
-  async like(event: APIEvent) {
+  async like(event: ApiEvent): ApiResponse {
     const albumId = event.pathParameters?.albumId
     if (!albumId) throw badRequest("albumId is required in path")
 
@@ -35,10 +35,10 @@ export class AlbumApi extends ApiViewBase {
     else return methodNotAllowed()
   }
 }
-export const handler: RequestHandler = async (event, context) => new AlbumApi().dispatch(event, context)
+export const handler = apiViewHandler(__filename, AlbumApi)
 
 // a simple standalone function with a route attached
-export async function topSongsHandler(event: APIEvent) {
+export async function topSongsHandler(event: ApiEvent) {
   return JSON.stringify({
     message: "function route",
     rawQueryString: event.rawQueryString,
@@ -64,7 +64,7 @@ const topSongsFuncInner = Route({
   },
   // this function name should match the exported name
   // or you must specify the exported function name in `handler`
-})(async function topSongsFuncInner(event: APIEvent) {
+})(async function topSongsFuncInner(event: ApiEvent) {
   return `cookies: ${event.cookies}`
 })
 export { topSongsFuncInner }

--- a/src/util/function.ts
+++ b/src/util/function.ts
@@ -8,7 +8,8 @@ export function findDefiningFile(fnName: string | null): string | undefined {
   let definingIndex
   const sites = callsites()
   for (const [index, site] of sites.entries()) {
-    console.log(`CALL SITE: ${site.getFunctionName()} - ${site.getFileName()}`)
+    // console.log(`CALL SITE: ${site.getFunctionName()} - ${site.getFileName()}`)
+
     if (site.getFunctionName() === fnName) {
       // The next site is the site where the function was called
       definingIndex = index + 1

--- a/src/util/function.ts
+++ b/src/util/function.ts
@@ -4,7 +4,7 @@ import callsites from "callsites"
  * Finds the name of the file where `fnName` was called.
  * Borrowed a bit from https://github.com/aws/aws-cdk/blob/v1.96.0/packages/@aws-cdk/aws-lambda-nodejs/lib/function.ts
  */
-export function findDefiningFile(fnName: string | null): string | null {
+export function findDefiningFile(fnName: string | null): string | undefined {
   let definingIndex
   const sites = callsites()
   for (const [index, site] of sites.entries()) {
@@ -17,8 +17,9 @@ export function findDefiningFile(fnName: string | null): string | null {
   }
 
   if (!definingIndex || !sites[definingIndex]) {
-    throw new Error("Cannot find defining file.")
+    // throw new Error("Cannot find defining file.")
+    return undefined
   }
 
-  return sites[definingIndex].getFileName()
+  return sites[definingIndex].getFileName() || undefined
 }


### PR DESCRIPTION
I should be able to declare a class like:

```typescript
@ApiView({
  path: "/album",
  memorySize: 512,
  environment: {
    LOG_LEVEL: "DEBUG",
  },
  bundling: { minify: true, metafile: true, sourceMap: true },
})
export class AlbumApi extends ApiViewBase {
  // define POST handler
  post = async () => "Created new album"

  // custom endpoint in the view
  // routes to the ApiView function
  @SubRoute({
    path: "/{albumId}/like", // will be /album/123/like
    methods: [HttpMethod.POST, HttpMethod.DELETE],
  })
  async like(event: ApiEvent): ApiResponse {
    const albumId = event.pathParameters?.albumId
    if (!albumId) throw badRequest("albumId is required in path")

    const method = event.requestContext.http.method

    // POST - mark album as liked
    if (method == HttpMethod.POST) return `Liked album ${albumId}`
    // DELETE - unmark album as liked
    else if (method == HttpMethod.DELETE) return `Unliked album ${albumId}`
    else return methodNotAllowed()
  }
}
export const handler = apiViewHandler(__filename, AlbumApi)
```

And JetKit should be able to figure out which method to call based on the APIGWProxyV2 Lambda event.