### PR TITLE
Route() -> Lambda()

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm install @jetkit/cdk
 ```typescript
 import { HttpMethod } from "@aws-cdk/aws-apigatewayv2"
 import { badRequest, methodNotAllowed } from "@jdpnielsen/http-error"
-import { ApiView, Route, SubRoute, ApiEvent, ApiResponse, ApiViewBase, apiViewHandler } from "@jetkit/cdk"
+import { ApiView, SubRoute, ApiEvent, ApiResponse, ApiViewBase, apiViewHandler } from "@jetkit/cdk"
 
 @ApiView({
   path: "/album",
@@ -79,14 +79,14 @@ export const handler = apiViewHandler(__filename, AlbumApi)
 
 ```typescript
 import { HttpMethod } from "@aws-cdk/aws-apigatewayv2"
-import { Route, ApiEvent } from "@jetkit/cdk"
+import { Lambda, ApiEvent } from "@jetkit/cdk"
 
 // a simple standalone function with a route attached
 export async function topSongsHandler(event: ApiEvent) {
   return "top songs"
 }
 // define route and lambda properties
-Route({
+Lambda({
   path: "/top-songs",
   methods: [HttpMethod.PUT],
   memorySize: 384,
@@ -96,7 +96,7 @@ Route({
 })(topSongsHandler)
 
 // alternate, uglier way of writing the same thing
-const topSongsFuncInner = Route({
+const topSongsFuncInner = Lambda({
   path: "/top-songs-inner",
   methods: [HttpMethod.PUT],
   memorySize: 384,

--- a/README.md
+++ b/README.md
@@ -3,12 +3,14 @@
 [![Tests](https://github.com/jetbridge/jetkit-cdk/actions/workflows/ci.yml/badge.svg)](https://github.com/jetbridge/jetkit-cdk/actions/workflows/ci.yml)
 [![npm version](https://badge.fury.io/js/%40jetkit%2Fcdk.svg)](https://badge.fury.io/js/%40jetkit%2Fcdk)
 
-An anti-framework for building cloud-native serverless applications.
+An [anti-framework](https://spiegelmock.com/2021/05/29/frameworkless-web-applications-aws-cdk/) for building cloud-native serverless applications.
 
 This module provides convenient tools for writing Lambda functions, RESTful API views,
 and generating cloud infrastructure with [AWS CDK](https://docs.aws.amazon.com/cdk/latest/guide/home.html).
 
 ## Motivation
+
+[Frameworkless web applications](https://spiegelmock.com/2021/05/29/frameworkless-web-applications-aws-cdk/).
 
 We want to build maintainable and scalable cloud-first applications, with cloud resources generated from application code.
 
@@ -21,13 +23,17 @@ functioning, keeping startup times low and applications modular.
 
 Guides and API reference can be found at [https://jetkit.dev/docs/](https://jetkit.dev/docs/).
 
+### Super Quickstart
+
+Use this monorepo project template: [typescript-cdk-template](https://github.com/jetbridge/typescript-cdk-template).
+
 ## Installation
 
 ```shell
 npm install @jetkit/cdk
 ```
 
-## Examples
+## Synopsis
 
 ### API View
 
@@ -84,8 +90,8 @@ export async function topSongsHandler(event: ApiEvent) {
 // define route and lambda properties
 Lambda({
   path: "/top-songs",
-  methods: [HttpMethod.PUT],
-  memorySize: 384,
+  methods: [HttpMethod.GET],
+  memorySize: 384
   environment: {
     LOG_LEVEL: "WARN",
   },
@@ -94,7 +100,7 @@ Lambda({
 // alternate, uglier way of writing the same thing
 const topSongsFuncInner = Lambda({
   path: "/top-songs-inner",
-  methods: [HttpMethod.PUT],
+  methods: [HttpMethod.GET],
   memorySize: 384,
   environment: {
     LOG_LEVEL: "WARN",
@@ -150,10 +156,6 @@ export class InfraStack extends Stack {
   }
 }
 ```
-
-### Super Quickstart
-
-Use this monorepo project template: [jkv2-ts-template](https://github.com/jetbridge/jkv2-ts-template)
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
+# JetKit/CDK
+
 [![Tests](https://github.com/jetbridge/jetkit-cdk/actions/workflows/ci.yml/badge.svg)](https://github.com/jetbridge/jetkit-cdk/actions/workflows/ci.yml)
 [![npm version](https://badge.fury.io/js/%40jetkit%2Fcdk.svg)](https://badge.fury.io/js/%40jetkit%2Fcdk)
-
-# JetKit/CDK
 
 An anti-framework for building cloud-native serverless applications.
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,27 @@
+[![Tests](https://github.com/jetbridge/jetkit-cdk/actions/workflows/ci.yml/badge.svg)](https://github.com/jetbridge/jetkit-cdk/actions/workflows/ci.yml)
+[![npm version](https://badge.fury.io/js/%40jetkit%2Fcdk.svg)](https://badge.fury.io/js/%40jetkit%2Fcdk)
+
 # JetKit/CDK
 
 An anti-framework for building cloud-native serverless applications.
 
-This module provides convenient tools for writing RESTful API views
+This module provides convenient tools for writing Lambda functions, RESTful API views,
 and generating cloud infrastructure with [AWS CDK](https://docs.aws.amazon.com/cdk/latest/guide/home.html).
-
-[![Tests](https://github.com/jetbridge/jetkit-cdk/actions/workflows/ci.yml/badge.svg)](https://github.com/jetbridge/jetkit-cdk/actions/workflows/ci.yml)
-[![npm version](https://badge.fury.io/js/%40jetkit%2Fcdk.svg)](https://badge.fury.io/js/%40jetkit%2Fcdk)
 
 ## Motivation
 
 We want to build maintainable and scalable cloud-first applications, with cloud resources generated from application code.
 
 Using AWS CDK we can automate generating API Gateway routes and Lambda functions from class and function metadata.
+
 Each class or function view is a self-contained Lambda function that only pulls in the dependencies needed for its
 functioning, keeping startup times low and applications modular.
-Get the utility of a minimal web framework without cramming your entire app into a single Lambda.
-
-Optional support for TypeORM using the Aurora Serverless Data API and convenient helpers for CRUD, serialization, tracing, and error handling will be added soon.
 
 ## Documentation
 
-Guides and API reference can be found at [https://jetbridge.github.io/jetkit-cdk/](https://jetbridge.github.io/jetkit-cdk/).
+Guides and API reference can be found at [https://jetkit.dev/docs/](https://jetkit.dev/docs/).
 
 ## Installation
-
-@jetkit/cdk runs on Node.js and is available as a NPM package.
 
 ```shell
 npm install @jetkit/cdk

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetkit/cdk",
-  "version": "0.0.39",
+  "version": "0.1.0",
   "description": "Cloud-native serverless development mini-framework",
   "types": "build/esm/index.d.ts",
   "main": "build/cjs/index.js",

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -84,6 +84,7 @@ export class ApiViewBase {
     const viewMeta = getApiViewMetadata(apiViewClass)
     const subRouteMetaMap = getSubRouteMetadata(apiViewClass)
     if (!viewMeta) throw new Error(`Metadata for dispatch not found on API view ${apiViewClass}`)
+    if (!viewMeta.path) return
 
     // is this request for the default view or a sub route?
     // does the route key match the base route?
@@ -121,6 +122,8 @@ export class ApiViewBase {
     // we should match any subRoute with that configuration
     for (const meta of subRouteMetaMap.values()) {
       const { methods, path, requestHandlerFunc } = meta
+      if (!viewMeta.path) return
+
       // full path is parent path + subRoute path
       const fullPath = viewMeta.path + path
       if (this.matchesRouteKey(routeKey, method, fullPath, methods)) return requestHandlerFunc

--- a/src/cdk/generator.ts
+++ b/src/cdk/generator.ts
@@ -10,7 +10,7 @@ import { SubRouteApi } from "./api/subRoute"
 /**
  * CDK {@link Construct} that automatically generates cloud resources
  * based on metadata defined on your application code using
- * {@link Route}, {@link ApiView}, {@link SubRoute}.
+ * {@link Lambda}, {@link ApiView}, {@link SubRoute}.
  *
  * @module
  */

--- a/src/cdk/generator.ts
+++ b/src/cdk/generator.ts
@@ -3,7 +3,7 @@ import { NodejsFunctionProps } from "@aws-cdk/aws-lambda-nodejs"
 import { Construct } from "@aws-cdk/core"
 import deepmerge from "deepmerge"
 import { RequestHandler } from "../api/base"
-import { getApiViewMetadata, getRouteMetadata, getSubRouteMetadata, MetadataTarget } from "../metadata"
+import { getApiViewMetadata, getFunctionMetadata, getSubRouteMetadata, MetadataTarget } from "../metadata"
 import { ApiProps, ApiView as ApiViewConstruct } from "./api/api"
 import { SubRouteApi } from "./api/subRoute"
 
@@ -65,7 +65,7 @@ export class ResourceGenerator extends Construct {
    * Create function handler for a simple routed function.
    */
   generateConstructsForFunction(resource: RequestHandler) {
-    const funcMeta = getRouteMetadata(resource)
+    const funcMeta = getFunctionMetadata(resource)
     if (!funcMeta) return
 
     const { requestHandlerFunc, ...rest } = funcMeta

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,9 @@ export { CrudApiViewBase } from "./api/crud/base"
 export { ApiViewBase, ApiEvent, ApiResponse, RequestHandler, apiViewHandler } from "./api/base"
 
 // metadata
-export { ApiView, Route, SubRoute, IRouteProps, ISubRouteProps } from "./registry"
+export { ApiView, Lambda as Route, SubRoute, IRouteProps, ISubRouteProps } from "./registry"
 export {
-  IApiMetadata,
+  IFunctionMetadataBase as IApiMetadata,
   IApiViewClassMetadata,
   ICrudApiMetadata,
   IFunctionMetadata,

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export { CrudApiViewBase } from "./api/crud/base"
 export { ApiViewBase, ApiEvent, ApiResponse, RequestHandler, apiViewHandler } from "./api/base"
 
 // metadata
-export { ApiView, Lambda as Route, SubRoute, IRouteProps, ISubRouteProps } from "./registry"
+export { ApiView, Lambda, SubRoute, IRouteProps, ISubRouteProps } from "./registry"
 export {
   IFunctionMetadataBase as IApiMetadata,
   IApiViewClassMetadata,

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -22,41 +22,42 @@ export const JK_V2_METADATA_API_VIEW_KEY = Symbol.for("jk:v2:metadata:api:view")
 export const JK_V2_METADATA_CRUD_API_KEY = Symbol.for("jk:v2:metadata:api:crud")
 // sub-route method inside a class
 export const JK_V2_METADATA_SUBROUTES_KEY = Symbol.for("jk:v2:metadata:subroutes")
-// standalone function-level route
-export const JK_V2_METADATA_ROUTE_KEY = Symbol.for("jk:v2:metadata:route")
+// standalone function
+export const JK_V2_METADATA_FUNCTION_KEY = Symbol.for("jk:v2:metadata:function")
 
-export type ApiMetadataMap<V extends IApiMetadata> = Map<string, V>
+export type ApiMetadataMap<V extends IFunctionMetadataBase> = Map<string, V>
 
 // what types of objects can have metadata attached?
 export type MetadataTarget = RequestHandler | MetadataTargetConstructor
 
 /**
- * Metadata describing any API route and lambda function.
+ * Metadata describing any Lambda function.
  */
-export interface IApiMetadata extends NodejsFunctionProps {
-  path: string
+export interface IFunctionMetadataBase extends NodejsFunctionProps {
+  path?: string
   entry?: string
   methods?: HttpMethod[]
 }
 
 /**
- * Function route.
+ * A Lambda function.
+ * Can be invoked via API route or otherwise.
  */
-export interface IFunctionMetadata extends IApiMetadata {
+export interface IFunctionMetadata extends IFunctionMetadataBase {
   requestHandlerFunc: RequestHandler
 }
 
 /**
  * APIView class.
  */
-export interface IApiViewClassMetadata extends IApiMetadata {
+export interface IApiViewClassMetadata extends IFunctionMetadataBase {
   apiClass: MetadataTargetConstructor
 }
 
 /**
  * CRUD view.
  */
-export interface ICrudApiMetadata extends IApiMetadata {
+export interface ICrudApiMetadata extends IFunctionMetadataBase {
   model?: typeof BaseModel // TODO: make not optional
   apiClass: MetadataTargetConstructor
 }
@@ -64,7 +65,7 @@ export interface ICrudApiMetadata extends IApiMetadata {
 /**
  * Sub-route method in an APIView class.
  */
-export interface ISubRouteApiMetadata extends IApiMetadata {
+export interface ISubRouteApiMetadata extends IFunctionMetadataBase {
   propertyKey: string
   requestHandlerFunc?: RequestHandler
 }
@@ -104,8 +105,8 @@ export const getSubRouteMetadata = (target: MetadataTarget): ApiMetadataMap<ISub
 export const setSubRouteMetadata = (target: MetadataTarget, value: ApiMetadataMap<ISubRouteApiMetadata>) =>
   setMemberMetadata(target, JK_V2_METADATA_SUBROUTES_KEY, value)
 
-// plain function route
-export const getRouteMetadata = (target: RequestHandler): IFunctionMetadata | undefined =>
-  getMemberMetadata(target, JK_V2_METADATA_ROUTE_KEY)
-export const setRouteMetadata = (target: RequestHandler, value: IFunctionMetadata) =>
-  setMemberMetadata(target, JK_V2_METADATA_ROUTE_KEY, value)
+// plain function
+export const getFunctionMetadata = (target: RequestHandler): IFunctionMetadata | undefined =>
+  getMemberMetadata(target, JK_V2_METADATA_FUNCTION_KEY)
+export const setFunctionMetadata = (target: RequestHandler, value: IFunctionMetadata) =>
+  setMemberMetadata(target, JK_V2_METADATA_FUNCTION_KEY, value)

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -131,7 +131,7 @@ export function Lambda(props: IRouteProps) {
       // it would be better to get the _exported_ name of the function that is being
       // decorated but I've no clue how to get that.
       throw new Error(
-        `This function is unnamed. Please define it using "async function foo() {...}" or explicitly pass the exported handler name to Route().\nFunction:\n${wrapped}\n\nThis is necessary to define the entrypoint handler name for the lambda function configuration.`
+        `This function is unnamed. Please define it using "async function foo() {...}" or explicitly pass the exported handler name to Lambda().\nFunction:\n${wrapped}\n\nThis is necessary to define the entrypoint handler name for the lambda function configuration.`
       )
     }
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -4,14 +4,14 @@ import fs from "fs"
 import { ApiViewBase, RequestHandler } from "./api/base"
 import {
   getSubRouteMetadata,
-  IApiMetadata,
+  IFunctionMetadataBase,
   IApiViewClassMetadata,
   IFunctionMetadata,
   ISubRouteApiMetadata,
   MetadataTarget,
   MetadataTargetConstructor,
   setApiViewMetadata,
-  setRouteMetadata,
+  setFunctionMetadata,
   setSubRouteMetadata,
 } from "./metadata"
 import { findDefiningFile } from "./util/function"
@@ -30,7 +30,7 @@ import { findDefiningFile } from "./util/function"
  *
  * @category Metadata Decorator
  */
-export function ApiView(opts: IApiMetadata) {
+export function ApiView(opts: IFunctionMetadataBase) {
   // try to guess the filename where this decorator is being applied
   if (!opts.entry) opts.entry = guessEntrypoint("ApiView")
 
@@ -104,18 +104,18 @@ export function SubRoute({ path, methods }: ISubRouteProps) {
 }
 
 /**
- * Defines a route and lambda handler for a function.
+ * Defines a Lambda function.
  *
  * Saves metadata on the function for generation of CDK resources.
  *
- * N.B. in order for the lambda entry handler to locate your function it must be named and exported
+ * N.B. in order for the Lambda entry handler to locate your function it must be named and exported
  * or you can manually provide the name of the exported handler in `props.handler`.
- * @param props configure route and any other lambda function properties including memory allocation and environment variables.
+ * @param props configure optional API route and any other lambda function properties including memory allocation and environment variables.
  * @returns
  *
  * @category Metadata Decorator
  */
-export function Route(props: IRouteProps) {
+export function Lambda(props: IRouteProps) {
   return (wrapped: RequestHandler) => {
     // here we figure out the entrypoint path and function handler name:
 
@@ -142,7 +142,7 @@ export function Route(props: IRouteProps) {
       requestHandlerFunc: wrapped,
     }
 
-    setRouteMetadata(wrapped, meta)
+    setFunctionMetadata(wrapped, meta)
     return wrapped
   }
 }

--- a/src/test/generateApiConstructs.spec.ts
+++ b/src/test/generateApiConstructs.spec.ts
@@ -79,7 +79,7 @@ describe("@SubRoute construct generation", () => {
   })
 })
 
-describe("@Route construct generation", () => {
+describe("@Lambda construct generation", () => {
   const stack = new Stack()
   const httpApi = new HttpApi(stack, "API")
 

--- a/src/test/readMetadata.spec.ts
+++ b/src/test/readMetadata.spec.ts
@@ -1,5 +1,5 @@
 import { HttpMethod } from "@aws-cdk/aws-apigatewayv2"
-import { getApiViewMetadata, getRouteMetadata, getSubRouteMetadata } from "../metadata"
+import { getApiViewMetadata, getFunctionMetadata, getSubRouteMetadata } from "../metadata"
 import { AlbumApi, topSongsFuncInner, topSongsHandler } from "./sampleApp"
 
 describe("Metadata decorators", () => {
@@ -32,9 +32,9 @@ describe("Metadata decorators", () => {
     })
   })
 
-  describe("Route()", () => {
-    it("stores metadata on functions with separate Route() call", () => {
-      const funcMeta = getRouteMetadata(topSongsHandler)
+  describe("Function()", () => {
+    it("stores metadata on functions with separate Lambda() call", () => {
+      const funcMeta = getFunctionMetadata(topSongsHandler)
       expect(funcMeta).toMatchObject({
         entry: /test\/sampleApp.ts$/,
         handler: "topSongsHandler",
@@ -46,8 +46,8 @@ describe("Metadata decorators", () => {
         },
       })
     })
-    it("stores metadata on functions wrapped with Route()", () => {
-      const funcMeta = getRouteMetadata(topSongsFuncInner)
+    it("stores metadata on functions wrapped with Lambda()", () => {
+      const funcMeta = getFunctionMetadata(topSongsFuncInner)
       expect(funcMeta).toMatchObject({
         entry: /test\/sampleApp.ts$/,
         handler: "topSongsFuncInner",

--- a/src/test/sampleApp.ts
+++ b/src/test/sampleApp.ts
@@ -1,7 +1,7 @@
 import { HttpMethod } from "@aws-cdk/aws-apigatewayv2"
 import { badRequest, methodNotAllowed } from "@jdpnielsen/http-error"
 import { ApiEvent, ApiResponse, ApiViewBase, apiViewHandler } from "../api/base"
-import { ApiView, Route, SubRoute } from "../registry"
+import { ApiView, Lambda, SubRoute } from "../registry"
 
 @ApiView({
   path: "/album",
@@ -44,7 +44,7 @@ export async function topSongsHandler(event: ApiEvent) {
   })
 }
 // define route and lambda properties
-Route({
+Lambda({
   path: "/top-songs",
   methods: [HttpMethod.PUT],
   memorySize: 384,
@@ -54,7 +54,7 @@ Route({
 })(topSongsHandler)
 
 // alternate, uglier way of writing the same thing
-const topSongsFuncInner = Route({
+const topSongsFuncInner = Lambda({
   path: "/top-songs-inner",
   methods: [HttpMethod.PUT],
   memorySize: 384,


### PR DESCRIPTION
The idea here is to make routes for functions optional. I believe we will want to create Lambda functions that are invoked in ways other than via API Gateway, such as cron jobs, invoked directly by other functions, or IoT events.

It should be easy enough to plug in different Lambda Integrations later on in `Lambda` wrappers.

I keep thinking `@Lambda` is a decorator but it isn't because TS doesn't support function decorators due to hoisting. 