### PR TITLE
Output routes and API URL

### DIFF
--- a/src/cdk/api/api.ts
+++ b/src/cdk/api/api.ts
@@ -1,7 +1,7 @@
 import { HttpApi, HttpMethod, PayloadFormatVersion } from "@aws-cdk/aws-apigatewayv2"
 import { LambdaProxyIntegration } from "@aws-cdk/aws-apigatewayv2-integrations"
 import { NodejsFunctionProps } from "@aws-cdk/aws-lambda-nodejs"
-import { Construct } from "@aws-cdk/core"
+import { CfnOutput, Construct } from "@aws-cdk/core"
 import { Node14Func } from "../lambda/node14func"
 
 /**
@@ -30,12 +30,21 @@ export interface IAddRoutes extends IEndpoint {
   lambdaApiIntegration: LambdaProxyIntegration
 }
 export abstract class ApiViewMixin extends Construct {
+  #routeOutputId = 1
+
   addRoutes({ methods, path = "/", httpApi, lambdaApiIntegration }: IAddRoutes) {
+    methods = methods || [HttpMethod.ANY]
     // * /path -> lambda integration
-    httpApi.addRoutes({
+    const routes = httpApi.addRoutes({
       path,
-      methods: methods || [HttpMethod.ANY],
+      methods,
       integration: lambdaApiIntegration,
+    })
+
+    // output the route for easily seeing at a glance what routes are generated
+    routes.forEach((route) => {
+      const routeId = `Route${this.#routeOutputId++}`
+      new CfnOutput(this, routeId, { exportName: routeId, value: `${methods?.join(",")} ${route.path}` || "*" })
     })
   }
 }

--- a/src/cdk/api/api.ts
+++ b/src/cdk/api/api.ts
@@ -42,10 +42,9 @@ export abstract class ApiViewMixin extends Construct {
     })
 
     // output the route for easily seeing at a glance what routes are generated
-    routes.forEach((route) => {
-      const routeId = `Route${this.#routeOutputId++}`
-      new CfnOutput(this, routeId, { exportName: routeId, value: `${methods?.join(",")} ${route.path}` || "*" })
-    })
+    const route = routes[0] // one for each method; don't care
+    const routeId = `Route${this.#routeOutputId++}`
+    new CfnOutput(this, routeId, { value: `${methods?.join(",")} ${route.path}` || "*" })
   }
 }
 

--- a/src/cdk/generator.ts
+++ b/src/cdk/generator.ts
@@ -1,6 +1,6 @@
 import { HttpApi } from "@aws-cdk/aws-apigatewayv2"
 import { NodejsFunctionProps } from "@aws-cdk/aws-lambda-nodejs"
-import { Construct } from "@aws-cdk/core"
+import { CfnOutput, Construct } from "@aws-cdk/core"
 import deepmerge from "deepmerge"
 import { RequestHandler } from "../api/base"
 import { getApiViewMetadata, getFunctionMetadata, getSubRouteMetadata, MetadataTarget } from "../metadata"
@@ -54,6 +54,9 @@ export class ResourceGenerator extends Construct {
 
     // emit CDK constructs for specified resources
     resources.forEach((resource) => this.generateConstructsForResource(resource))
+
+    // it's handy to have the API base URL as a stack output
+    if (this.httpApi) new CfnOutput(this, "ApiBase", { exportName: "ApiBase", value: this.httpApi.url || "Unknown" })
   }
 
   generateConstructsForResource(resource: MetadataTarget) {

--- a/src/cdk/lambda/node14func.ts
+++ b/src/cdk/lambda/node14func.ts
@@ -25,9 +25,6 @@ export class Node14Func extends NodejsFunction {
     // node 14
     runtime ||= Runtime.NODEJS_14_X
 
-    // https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/node-reusing-connections.html
-    if (typeof awsSdkConnectionReuse === "undefined") awsSdkConnectionReuse = true
-
     // we should preserve function names for introspection
     // https://esbuild.github.io/api/#keep-names
     bundling ||= {}

--- a/src/test/generateApiConstructs.spec.ts
+++ b/src/test/generateApiConstructs.spec.ts
@@ -82,6 +82,33 @@ describe("@SubRoute construct generation", () => {
       outputName: "GenSubRoutelikeRoute176CE77B5",
       outputValue: "POST,DELETE /album/{albumId}/like",
     })
+    expect(stack).toHaveOutput({
+      outputName: "GenClassAlbumApiRoute1AA2A9EC9",
+      outputValue: "ANY /album",
+    })
+    expect(stack).toHaveOutput({
+      exportName: "ApiBase",
+      outputValue: {
+        "Fn::Join": [
+          "",
+          [
+            "https://",
+            {
+              Ref: "API62EA1CFF",
+            },
+            ".execute-api.",
+            {
+              Ref: "AWS::Region",
+            },
+            ".",
+            {
+              Ref: "AWS::URLSuffix",
+            },
+            "/",
+          ],
+        ],
+      },
+    })
   })
 })
 

--- a/src/test/generateApiConstructs.spec.ts
+++ b/src/test/generateApiConstructs.spec.ts
@@ -77,6 +77,12 @@ describe("@SubRoute construct generation", () => {
       RouteKey: "POST /album/{albumId}/like",
     })
   })
+  it("has route outputs", () => {
+    expect(stack).toHaveOutput({
+      outputName: "GenSubRoutelikeRoute176CE77B5",
+      outputValue: "POST,DELETE /album/{albumId}/like",
+    })
+  })
 })
 
 describe("@Lambda construct generation", () => {


### PR DESCRIPTION
Just to make life a little easier it will now create CF outputs for the API base URL and the routes that are defined

<img width="993" alt="Screen Shot 2021-06-02 at 1 00 48 PM" src="https://user-images.githubusercontent.com/245131/120461582-cb6d7a80-c3a2-11eb-8a07-1cf3fab98240.png">

<img width="1218" alt="Screen Shot 2021-06-02 at 1 05 01 PM" src="https://user-images.githubusercontent.com/245131/120461956-27d09a00-c3a3-11eb-9089-fac2a0afad90.png">
