### PR TITLE
Make versioning scheme based on version of CDK the library is tested against

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetkit/cdk",
-  "version": "0.4.8",
+  "version": "1.110.0",
   "description": "Cloud-native serverless anti-framework",
   "types": "build/esm/index.d.ts",
   "main": "build/cjs/index.js",


### PR DESCRIPTION
So our major/minor versions line up with the CDK version to make it clearer what CDK version it's compatible with