### PR TITLE
Look up generated function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jetkit/cdk",
-  "version": "1.115.2",
+  "version": "1.115.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@jetkit/cdk",
-      "version": "1.115.2",
+      "version": "1.115.4",
       "license": "MIT",
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2": "1.115.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetkit/cdk",
-  "version": "1.115.3",
+  "version": "1.115.4",
   "description": "Cloud-native serverless anti-framework",
   "types": "build/esm/index.d.ts",
   "main": "build/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetkit/cdk",
-  "version": "1.115.2",
+  "version": "1.115.3",
   "description": "Cloud-native serverless anti-framework",
   "types": "build/esm/index.d.ts",
   "main": "build/cjs/index.js",

--- a/src/cdk/api/api.ts
+++ b/src/cdk/api/api.ts
@@ -1,9 +1,8 @@
 import { HttpApi, HttpMethod, PayloadFormatVersion } from "@aws-cdk/aws-apigatewayv2"
 import { LambdaProxyIntegration } from "@aws-cdk/aws-apigatewayv2-integrations"
-import { NodejsFunction } from "@aws-cdk/aws-lambda-nodejs"
 import { CfnOutput, Construct } from "@aws-cdk/core"
 import { FunctionOptions } from "../generator"
-import { Node14Func as JetKitLambdaFunction, Node14FuncProps as JetKitLambdaFunctionProps } from "../lambda/node14func"
+import { Node14FuncProps as JetKitLambdaFunctionProps, Node14Func as JetKitLambdaFunction } from "../lambda/node14func"
 
 export { JetKitLambdaFunction, JetKitLambdaFunctionProps }
 
@@ -13,7 +12,7 @@ export { JetKitLambdaFunction, JetKitLambdaFunctionProps }
 export interface ApiConfig extends FunctionOptions, IEndpoint {}
 
 export interface ApiProps extends ApiConfig {
-  handlerFunction: NodejsFunction
+  handlerFunction: JetKitLambdaFunction
 }
 
 export interface IEndpoint {

--- a/src/cdk/generator.test.ts
+++ b/src/cdk/generator.test.ts
@@ -10,6 +10,7 @@ import * as path from "path"
 import { ApiViewConstruct, ResourceGeneratorConstruct } from ".."
 import { AlbumApi, scheduledFunc, topSongsFuncInner, topSongsHandler } from "../test/sampleApp"
 import { ApiView, JetKitLambdaFunction } from "./api/api"
+import { Node14Func } from "./lambda/node14func"
 
 const bundleBannerMsg = "--- cool bundlings mon ---"
 
@@ -70,6 +71,20 @@ describe("@ApiView construct generation", () => {
   it("saves generated functions", () => {
     expect(generator.generatedFunctions).toHaveLength(1)
     expect(generator.generatedFunctions[0]).toBeInstanceOf(NodejsFunction)
+  })
+
+  it("can find APIView function by name", () => {
+    const found = generator.getFunction({ name: "AlbumApi" })
+    expect(found).toBeTruthy()
+    expect(found).toBeInstanceOf(Node14Func)
+    expect(found?.name).toEqual("AlbumApi")
+  })
+
+  it("can find APIView function by cctor", () => {
+    const found = generator.getFunction({ ctor: AlbumApi })
+    expect(found).toBeTruthy()
+    expect(found).toBeInstanceOf(Node14Func)
+    expect(found?.name).toEqual("AlbumApi")
   })
 
   it("generates APIGW routes", () => {
@@ -218,6 +233,20 @@ describe("Lambda() construct generation of APIs", () => {
     expect(generator.generatedFunctions).toHaveLength(2)
     expect(generator.generatedFunctions[0]).toBeInstanceOf(NodejsFunction)
     expect(generator.generatedFunctions[1]).toBeInstanceOf(NodejsFunction)
+  })
+
+  it("can find Lambda function by ctor", () => {
+    const found = generator.getFunction({ ctor: topSongsHandler })
+    expect(found).toBeTruthy()
+    expect(found).toBeInstanceOf(Node14Func)
+    expect(found?.name).toEqual("topSongsHandler")
+  })
+
+  it("can find Lambda function by name", () => {
+    const found = generator.getFunction({ name: "topSongsHandler" })
+    expect(found).toBeTruthy()
+    expect(found).toBeInstanceOf(Node14Func)
+    expect(found?.name).toEqual("topSongsHandler")
   })
 
   it("generates endpoints for standalone functions", () => {

--- a/src/cdk/lambda/node14func.ts
+++ b/src/cdk/lambda/node14func.ts
@@ -70,7 +70,6 @@ export class Node14Func extends NodejsFunction {
   }
 
   getMetadataTarget(): MetadataTarget | undefined {
-    console.log("META TARGET", this.metadataTarget?.deref())
     return this.metadataTarget?.deref()
   }
 }

--- a/src/cdk/lambda/node14func.ts
+++ b/src/cdk/lambda/node14func.ts
@@ -2,8 +2,50 @@ import "source-map-support/register"
 import { BundlingOptions, NodejsFunction, NodejsFunctionProps } from "@aws-cdk/aws-lambda-nodejs"
 import { Construct } from "@aws-cdk/core"
 import { Runtime } from "@aws-cdk/aws-lambda"
+import { MetadataTarget } from "../../metadata"
 
-export type Node14FuncProps = NodejsFunctionProps
+export interface Node14FuncProps extends NodejsFunctionProps {
+  // reference to metadata used to generate this function
+  metadataTarget?: MetadataTarget
+
+  // function or class name this was generated from
+  name?: string
+}
+
+function addPropDefaults({
+  environment,
+  runtime,
+  bundling,
+  metadataTarget,
+  name,
+  ...rest
+}: Node14FuncProps): Node14FuncProps {
+  // default to source map support in node enabled
+  // makes your stack traces look nicer if sourceMap is turned on
+  environment ||= {}
+  if (!environment.NODE_OPTIONS) environment.NODE_OPTIONS = "--enable-source-maps"
+
+  // node 14
+  runtime ||= Runtime.NODEJS_14_X
+
+  // we should preserve function names for introspection
+  // https://esbuild.github.io/api/#keep-names
+  bundling ||= {}
+  let { keepNames, ...bundlingRest } = bundling
+  if (typeof keepNames == "undefined") keepNames = true
+
+  const newProps: NodejsFunctionProps = {
+    ...rest,
+    environment,
+    runtime,
+    bundling: {
+      keepNames,
+      ...bundlingRest,
+    },
+  }
+
+  return newProps
+}
 
 /**
  * Lambda function with agreeable defaults.
@@ -12,36 +54,23 @@ export type Node14FuncProps = NodejsFunctionProps
  */
 export class Node14Func extends NodejsFunction {
   bundling?: BundlingOptions
+  protected metadataTarget?: WeakRef<MetadataTarget>
+  name?: string
 
   constructor(scope: Construct, id: string, props: Node14FuncProps) {
-    let { environment, runtime, bundling, ...rest } = props
+    super(scope, id, addPropDefaults(props))
 
-    // default to source map support in node enabled
-    // makes your stack traces look nicer if sourceMap is turned on
-    environment ||= {}
-    if (!environment.NODE_OPTIONS) environment.NODE_OPTIONS = "--enable-source-maps"
+    let { metadataTarget, name, ...rest } = props
+    this.bundling = rest.bundling
+    this.name = name
 
-    // node 14
-    runtime ||= Runtime.NODEJS_14_X
+    // save a weak reference to the function or class's metadata we were generated for
+    // it's a circular reference so we keep a weak ref
+    if (metadataTarget) this.metadataTarget = new WeakRef(metadataTarget)
+  }
 
-    // we should preserve function names for introspection
-    // https://esbuild.github.io/api/#keep-names
-    bundling ||= {}
-    let { keepNames, ...bundlingRest } = bundling
-    if (typeof keepNames == "undefined") keepNames = true
-
-    const newProps: NodejsFunctionProps = {
-      ...rest,
-      environment,
-      runtime,
-      bundling: {
-        keepNames,
-        ...bundlingRest,
-      },
-    }
-
-    super(scope, id, newProps)
-
-    this.bundling = bundling
+  getMetadataTarget(): MetadataTarget | undefined {
+    console.log("META TARGET", this.metadataTarget?.deref())
+    return this.metadataTarget?.deref()
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export {
   DB_NAME_ENV,
   DB_SECRET_ENV,
   DB_URL_ENV,
+  GeneratedFunction,
 } from "./cdk/generator"
 
 // convient AWS CDK utilities to have

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,8 @@
     // I hope this works someday!
     "module": "es2020" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
 
+    "lib": ["ESNext"],
+
     "moduleResolution": "node", // modern
     "resolveJsonModule": true, // allow importing JSON filees
     "experimentalDecorators": true, // enable decorators


### PR DESCRIPTION
I'm still working out the best way to approach the issue that sometimes in CDK-land we want to get a reference to a function that was generated by our Function Generator.
There are often times where we want to do this, for example to get a reference to the lambda Function to grant it certain permissions, use it as a target for another service (e.g. appsync or cognito), give some other policy access to it, and more.

I'm still trying to figure out the cleanest way to do this. Previously (#12) I was doing this with a post-creation callback which works pretty well except that it's a major headache to do it with proper typing. Here I am adding the ability to grab the generated Function by passing a reference to the actual handler function or its name. I'm not sure it's the ideal solution but I'm going to see if it works well enough to unblock me.