### PR TITLE
Flag for marking routes as unauthenticated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2": "1.115.0",
+        "@aws-cdk/aws-apigatewayv2-authorizers": "1.115.0",
         "@aws-cdk/aws-apigatewayv2-integrations": "1.115.0",
         "@aws-cdk/aws-ec2": "1.115.0",
         "@aws-cdk/aws-events": "1.115.0",
@@ -164,6 +165,30 @@
         "@aws-cdk/aws-cloudwatch": "1.115.0",
         "@aws-cdk/aws-ec2": "1.115.0",
         "@aws-cdk/aws-iam": "1.115.0",
+        "@aws-cdk/core": "1.115.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-apigatewayv2-authorizers": {
+      "version": "1.115.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-authorizers/-/aws-apigatewayv2-authorizers-1.115.0.tgz",
+      "integrity": "sha512-zJNZQ06LKzkDFTfG2/EsqI53dBieippFsDHk1JcuKKo5WsoQJuOXG/Q/U96bwrx4XZaxxHJL1EdOFp23Rdijuw==",
+      "dependencies": {
+        "@aws-cdk/aws-apigatewayv2": "1.115.0",
+        "@aws-cdk/aws-cognito": "1.115.0",
+        "@aws-cdk/aws-iam": "1.115.0",
+        "@aws-cdk/aws-lambda": "1.115.0",
+        "@aws-cdk/core": "1.115.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-apigatewayv2": "1.115.0",
+        "@aws-cdk/aws-cognito": "1.115.0",
+        "@aws-cdk/aws-iam": "1.115.0",
+        "@aws-cdk/aws-lambda": "1.115.0",
         "@aws-cdk/core": "1.115.0",
         "constructs": "^3.3.69"
       }
@@ -15634,6 +15659,19 @@
         "@aws-cdk/aws-cloudwatch": "1.115.0",
         "@aws-cdk/aws-ec2": "1.115.0",
         "@aws-cdk/aws-iam": "1.115.0",
+        "@aws-cdk/core": "1.115.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-apigatewayv2-authorizers": {
+      "version": "1.115.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-authorizers/-/aws-apigatewayv2-authorizers-1.115.0.tgz",
+      "integrity": "sha512-zJNZQ06LKzkDFTfG2/EsqI53dBieippFsDHk1JcuKKo5WsoQJuOXG/Q/U96bwrx4XZaxxHJL1EdOFp23Rdijuw==",
+      "requires": {
+        "@aws-cdk/aws-apigatewayv2": "1.115.0",
+        "@aws-cdk/aws-cognito": "1.115.0",
+        "@aws-cdk/aws-iam": "1.115.0",
+        "@aws-cdk/aws-lambda": "1.115.0",
         "@aws-cdk/core": "1.115.0",
         "constructs": "^3.3.69"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jetkit/cdk",
-  "version": "1.115.7",
+  "version": "1.115.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@jetkit/cdk",
-      "version": "1.115.7",
+      "version": "1.115.8",
       "license": "MIT",
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2": "1.115.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jetkit/cdk",
-  "version": "1.115.5",
+  "version": "1.115.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@jetkit/cdk",
-      "version": "1.115.5",
+      "version": "1.115.4",
       "license": "MIT",
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2": "1.115.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jetkit/cdk",
-  "version": "1.115.6",
+  "version": "1.115.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@jetkit/cdk",
-      "version": "1.115.6",
+      "version": "1.115.7",
       "license": "MIT",
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2": "1.115.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jetkit/cdk",
-  "version": "1.115.4",
+  "version": "1.115.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@jetkit/cdk",
-      "version": "1.115.4",
+      "version": "1.115.6",
       "license": "MIT",
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2": "1.115.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetkit/cdk",
-  "version": "1.115.5",
+  "version": "1.115.3",
   "description": "Cloud-native serverless anti-framework",
   "types": "build/esm/index.d.ts",
   "main": "build/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetkit/cdk",
-  "version": "1.115.3",
+  "version": "1.115.4",
   "description": "Cloud-native serverless anti-framework",
   "types": "build/esm/index.d.ts",
   "main": "build/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetkit/cdk",
-  "version": "1.115.4",
+  "version": "1.115.6",
   "description": "Cloud-native serverless anti-framework",
   "types": "build/esm/index.d.ts",
   "main": "build/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetkit/cdk",
-  "version": "1.115.7",
+  "version": "1.115.8",
   "description": "Cloud-native serverless anti-framework",
   "types": "build/esm/index.d.ts",
   "main": "build/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -54,9 +54,8 @@
     "typescript": "^4.2.4"
   },
   "dependencies": {
-    "reflect-metadata": "^0.1.13",
-    "@aws-sdk/client-secrets-manager": "^3.21.0",
     "@aws-cdk/aws-apigatewayv2": "1.115.0",
+    "@aws-cdk/aws-apigatewayv2-authorizers": "1.115.0",
     "@aws-cdk/aws-apigatewayv2-integrations": "1.115.0",
     "@aws-cdk/aws-ec2": "1.115.0",
     "@aws-cdk/aws-events": "1.115.0",
@@ -66,11 +65,13 @@
     "@aws-cdk/aws-lambda-nodejs": "1.115.0",
     "@aws-cdk/aws-rds": "1.115.0",
     "@aws-cdk/aws-secretsmanager": "1.115.0",
+    "@aws-sdk/client-secrets-manager": "^3.21.0",
     "@jdpnielsen/http-error": "^1.2.0",
     "aws-xray-sdk": "^3.3.3",
     "convict": "^6.1.0",
     "deepmerge": "^4.2.2",
-    "is-plain-object": "^2.0.4"
+    "is-plain-object": "^2.0.4",
+    "reflect-metadata": "^0.1.13"
   },
   "peerDependenciesMeta": {
     "prisma": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetkit/cdk",
-  "version": "1.115.6",
+  "version": "1.115.7",
   "description": "Cloud-native serverless anti-framework",
   "types": "build/esm/index.d.ts",
   "main": "build/cjs/index.js",

--- a/src/cdk/api/api.ts
+++ b/src/cdk/api/api.ts
@@ -1,6 +1,13 @@
-import { HttpApi, HttpMethod, PayloadFormatVersion } from "@aws-cdk/aws-apigatewayv2"
+import {
+  AddRoutesOptions,
+  HttpApi,
+  HttpMethod,
+  HttpNoneAuthorizer,
+  PayloadFormatVersion,
+} from "@aws-cdk/aws-apigatewayv2"
 import { LambdaProxyIntegration } from "@aws-cdk/aws-apigatewayv2-integrations"
 import { CfnOutput, Construct } from "@aws-cdk/core"
+import { IRoutePropsBase } from "../../registry"
 import { FunctionOptions } from "../generator"
 import { Node14FuncProps as JetKitLambdaFunctionProps, Node14Func as JetKitLambdaFunction } from "../lambda/node14func"
 
@@ -15,40 +22,34 @@ export interface ApiProps extends ApiConfig {
   handlerFunction: JetKitLambdaFunction
 }
 
-export interface IEndpoint {
+export interface IEndpoint extends Partial<IRoutePropsBase> {
   /**
    * API Gateway HTTP API
    */
   httpApi: HttpApi
-
-  /**
-   * Route
-   */
-  path?: string
-
-  /**
-   * Enabled {@link HttpMethod}s for route
-   */
-  methods?: HttpMethod[]
 }
 
 let routeOutputId = 1
 
 export interface IAddRoutes extends IEndpoint {
   lambdaApiIntegration: LambdaProxyIntegration
+  unauthorized?: boolean
 }
+
 export abstract class ApiViewMixin extends Construct {
-  addRoutes({ methods, path = "/", httpApi, lambdaApiIntegration }: IAddRoutes) {
+  addRoutes({ methods, path = "/", httpApi, lambdaApiIntegration, unauthorized }: IAddRoutes) {
     methods = methods || [HttpMethod.ANY]
 
     if (!methods.length) return
 
-    // * /path -> lambda integration
-    const routes = httpApi.addRoutes({
+    const routeOptions: AddRoutesOptions = {
       path,
       methods,
       integration: lambdaApiIntegration,
-    })
+      // disable authorization?
+      ...(unauthorized ? { authorizer: new HttpNoneAuthorizer() } : {}),
+    }
+    const routes = httpApi.addRoutes(routeOptions)
 
     // output the route for easily seeing at a glance what routes are generated
     const route = routes[0] // one for each method; don't care
@@ -72,7 +73,11 @@ export class ApiView extends ApiViewMixin implements IEndpoint {
   handlerFunction: JetKitLambdaFunction
   lambdaApiIntegration: LambdaProxyIntegration
 
-  constructor(scope: Construct, id: string, { httpApi, methods, path = "/", handlerFunction }: ApiProps) {
+  constructor(
+    scope: Construct,
+    id: string,
+    { httpApi, methods, path = "/", handlerFunction, unauthenticated }: ApiProps
+  ) {
     super(scope, id)
 
     // lambda handler
@@ -86,7 +91,7 @@ export class ApiView extends ApiViewMixin implements IEndpoint {
 
     this.httpApi = httpApi
     this.path = path
-    const routes: IAddRoutes = { httpApi, path, lambdaApiIntegration: this.lambdaApiIntegration }
+    const routes: IAddRoutes = { httpApi, path, lambdaApiIntegration: this.lambdaApiIntegration, unauthenticated }
     if (methods) {
       this.methods = methods
       routes.methods = methods

--- a/src/cdk/api/api.ts
+++ b/src/cdk/api/api.ts
@@ -73,11 +73,7 @@ export class ApiView extends ApiViewMixin implements IEndpoint {
   handlerFunction: JetKitLambdaFunction
   lambdaApiIntegration: LambdaProxyIntegration
 
-  constructor(
-    scope: Construct,
-    id: string,
-    { httpApi, methods, path = "/", handlerFunction, unauthenticated }: ApiProps
-  ) {
+  constructor(scope: Construct, id: string, { httpApi, methods, path = "/", handlerFunction, unauthorized }: ApiProps) {
     super(scope, id)
 
     // lambda handler
@@ -91,7 +87,7 @@ export class ApiView extends ApiViewMixin implements IEndpoint {
 
     this.httpApi = httpApi
     this.path = path
-    const routes: IAddRoutes = { httpApi, path, lambdaApiIntegration: this.lambdaApiIntegration, unauthenticated }
+    const routes: IAddRoutes = { httpApi, path, lambdaApiIntegration: this.lambdaApiIntegration, unauthorized }
     if (methods) {
       this.methods = methods
       routes.methods = methods

--- a/src/cdk/generator.test.ts
+++ b/src/cdk/generator.test.ts
@@ -316,12 +316,6 @@ describe("Authorization", () => {
       RouteKey: "ANY /unauthenticated",
       AuthorizationType: "NONE",
     })
-    expect(stack).toHaveResource("AWS::Lambda::Function", {
-      Environment: {
-        Variables: defaultEnvVars,
-      },
-      Handler: "index.unauthFunc",
-    })
   })
 
   it("disables authentication for ApiView", () => {
@@ -333,12 +327,6 @@ describe("Authorization", () => {
     expect(stack).toHaveResource("AWS::ApiGatewayV2::Route", {
       RouteKey: "ANY /unauthView",
       AuthorizationType: "NONE",
-    })
-    expect(stack).toHaveResource("AWS::Lambda::Function", {
-      Environment: {
-        Variables: defaultEnvVars,
-      },
-      Handler: "index.handler",
     })
   })
 })

--- a/src/cdk/generator.test.ts
+++ b/src/cdk/generator.test.ts
@@ -253,6 +253,7 @@ describe("Lambda() construct generation of APIs", () => {
   it("generates endpoints for standalone functions", () => {
     expect(stack).toHaveResource("AWS::ApiGatewayV2::Route", {
       RouteKey: "PUT /top-songs",
+      AuthorizationScopes: ["charts:read"],
     })
     expect(stack).toHaveResource("AWS::Lambda::Function", {
       Environment: {

--- a/src/cdk/generator.test.ts
+++ b/src/cdk/generator.test.ts
@@ -3,7 +3,8 @@
 import { stringLike } from "@aws-cdk/assert"
 import "@aws-cdk/assert/jest"
 import { HttpApi, HttpMethod } from "@aws-cdk/aws-apigatewayv2"
-import { FunctionOptions } from "@aws-cdk/aws-lambda"
+import { HttpLambdaAuthorizer, HttpLambdaResponseType } from "@aws-cdk/aws-apigatewayv2-authorizers"
+import { Code, Function, FunctionOptions, Runtime } from "@aws-cdk/aws-lambda"
 import { NodejsFunction } from "@aws-cdk/aws-lambda-nodejs"
 import { Duration, Stack } from "@aws-cdk/core"
 import * as path from "path"
@@ -290,7 +291,19 @@ describe("Authorization", () => {
 
   beforeEach(() => {
     stack = new Stack()
-    httpApi = new HttpApi(stack, "API")
+
+    // dummy authorizer
+    const authHandler = new Function(stack, "auth-function", {
+      code: Code.fromInline("1"),
+      runtime: Runtime.NODEJS,
+      handler: "main",
+    })
+    const authorizer = new HttpLambdaAuthorizer({
+      handler: authHandler,
+      authorizerName: "dummy",
+    })
+
+    httpApi = new HttpApi(stack, "API", { defaultAuthorizer: authorizer })
   })
 
   it("disables authentication functions", () => {

--- a/src/cdk/generator.ts
+++ b/src/cdk/generator.ts
@@ -183,9 +183,7 @@ export class ResourceGenerator extends Construct {
     functionOptions: FunctionOptions
   ): JetKitLambdaFunction {
     let { functionName, ...rest } = functionOptions
-
-    // disable CDK name mangling for the function name
-    if (this.functionPrefix) functionName ||= `${this.functionPrefix}-${name}`
+    functionName ||= this.generateFunctionName(name, functionOptions)
 
     // build Node Lambda function
     const handlerFunction = new JetKitLambdaFunction(this, `F${this.funcCounter++}-${name}`, {

--- a/src/cdk/generator.ts
+++ b/src/cdk/generator.ts
@@ -2,7 +2,7 @@
 import { HttpApi } from "@aws-cdk/aws-apigatewayv2"
 import { Rule } from "@aws-cdk/aws-events"
 import { Function, LayerVersion } from "@aws-cdk/aws-lambda"
-import { Aws, CfnOutput, Construct, Fn, Stack } from "@aws-cdk/core"
+import { Aws, CfnOutput, Construct, Fn } from "@aws-cdk/core"
 import deepmerge from "deepmerge"
 import isPlainObject from "is-plain-object"
 import { ApiHandler } from "../api/base"
@@ -99,7 +99,6 @@ export class ResourceGenerator extends Construct {
    * Lambda functions that were generated.
    */
   generatedFunctions: GeneratedFunction[]
-  functionPrefix?: string
 
   private layerCounter = 1
   private funcCounter = 1
@@ -179,15 +178,11 @@ export class ResourceGenerator extends Construct {
   protected createLambdaFunction(
     name: string,
     metadataTarget: MetadataTarget,
-    functionOptions: FunctionOptions
+    funcOptions: FunctionOptions
   ): JetKitLambdaFunction {
-    let { functionName, ...rest } = functionOptions
-    functionName ||= this.generateFunctionName(name, functionOptions)
-
     // build Node Lambda function
     const handlerFunction = new JetKitLambdaFunction(this, `F${this.funcCounter++}-${name}`, {
-      ...rest,
-      functionName,
+      ...funcOptions,
       name,
       metadataTarget,
     })

--- a/src/cdk/generator.ts
+++ b/src/cdk/generator.ts
@@ -2,7 +2,7 @@
 import { HttpApi } from "@aws-cdk/aws-apigatewayv2"
 import { Rule } from "@aws-cdk/aws-events"
 import { Function, LayerVersion } from "@aws-cdk/aws-lambda"
-import { Aws, CfnOutput, Construct, Fn } from "@aws-cdk/core"
+import { Aws, CfnOutput, Construct, Fn, Stack } from "@aws-cdk/core"
 import deepmerge from "deepmerge"
 import isPlainObject from "is-plain-object"
 import { ApiHandler } from "../api/base"
@@ -100,6 +100,8 @@ export class ResourceGenerator extends Construct {
    */
   generatedFunctions: GeneratedFunction[]
 
+  functionPrefix?: string
+
   private layerCounter = 1
   private funcCounter = 1
   private viewCounter = 1
@@ -178,11 +180,18 @@ export class ResourceGenerator extends Construct {
   protected createLambdaFunction(
     name: string,
     metadataTarget: MetadataTarget,
-    funcOptions: FunctionOptions
+    functionOptions: FunctionOptions
   ): JetKitLambdaFunction {
+    let { functionName, ...rest } = functionOptions
+
+    // disable CDK name mangling for the function name
+    if (this.functionPrefix) functionName ||= `${this.functionPrefix}-${name}`
+
     // build Node Lambda function
     const handlerFunction = new JetKitLambdaFunction(this, `F${this.funcCounter++}-${name}`, {
-      ...funcOptions,
+      ...rest,
+      functionName,
+
       name,
       metadataTarget,
     })

--- a/src/cdk/lambda/node14func.ts
+++ b/src/cdk/lambda/node14func.ts
@@ -71,7 +71,6 @@ export class Node14Func extends NodejsFunction {
   }
 
   getMetadataTarget(): MetadataTarget | undefined {
-    console.log("META TARGET", this.metadataTarget?.deref())
     return this.metadataTarget?.deref()
   }
 }

--- a/src/cdk/lambda/node14func.ts
+++ b/src/cdk/lambda/node14func.ts
@@ -71,6 +71,7 @@ export class Node14Func extends NodejsFunction {
   }
 
   getMetadataTarget(): MetadataTarget | undefined {
+    console.log("META TARGET", this.metadataTarget?.deref())
     return this.metadataTarget?.deref()
   }
 }

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -56,6 +56,14 @@ export interface IFunctionMetadataBase extends FunctionOptions {
    * Triggers a CloudWatch Event.
    */
   schedule?: Schedule
+
+  /**
+   * Disable default authorizer.
+   *
+   * Set to true for routes that do not require authentication
+   * if your routes normally require it.
+   */
+  unauthorized?: boolean
 }
 
 /**

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,4 +1,4 @@
-import { HttpMethod } from "@aws-cdk/aws-apigatewayv2"
+import { HttpMethod, HttpRouteProps } from "@aws-cdk/aws-apigatewayv2"
 import { Schedule } from "@aws-cdk/aws-events"
 import { ScheduledHandler } from "aws-lambda"
 import fs from "fs"
@@ -57,7 +57,7 @@ interface RoutePropertyDescriptor extends PropertyDescriptor {
   value?: ApiHandler
 }
 
-export interface IRoutePropsBase {
+export interface IRoutePropsBase extends Partial<HttpRouteProps> {
   /**
    * Route.
    *

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -71,7 +71,7 @@ export interface IRoutePropsBase {
   methods?: HttpMethod[]
 
   // disable authorization?
-  unauthenticated?: boolean
+  unauthorized?: boolean
 }
 
 export type ISubRouteProps = IRoutePropsBase

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -57,15 +57,26 @@ interface RoutePropertyDescriptor extends PropertyDescriptor {
   value?: ApiHandler
 }
 
-export interface ISubRouteProps {
+export interface IRoutePropsBase {
+  /**
+   * Route.
+   *
+   * e.g. "/v1/foo/bar"
+   */
   path: string
+
+  /**
+   * Enabled {@link HttpMethod}s for route
+   */
   methods?: HttpMethod[]
+
+  // disable authorization?
+  unauthenticated?: boolean
 }
 
-export interface IRouteProps extends FunctionOptions {
-  path: string
-  methods?: HttpMethod[]
-}
+export type ISubRouteProps = IRoutePropsBase
+
+export interface IRouteProps extends FunctionOptions, IRoutePropsBase {}
 
 export interface IScheduledProps extends FunctionOptions {
   schedule: Schedule
@@ -129,7 +140,7 @@ export type PossibleLambdaHandlers = ApiHandler | ScheduledHandler
  * @category Metadata Decorator
  */
 export function Lambda<HandlerT extends PossibleLambdaHandlers = PossibleLambdaHandlers>(
-  props: IRouteProps | IScheduledProps
+  props: Partial<IRouteProps> | IScheduledProps
 ) {
   return (wrapped: HandlerT) => {
     // here we figure out the entrypoint path and function handler name:

--- a/src/test/sampleApp.ts
+++ b/src/test/sampleApp.ts
@@ -81,12 +81,13 @@ Lambda({
 // unauthenticated route
 export const unauthFunc = () => console.log("does not require authentication")
 Lambda({
-  unauthenticated: true,
+  unauthorized: true,
   path: "/unauthenticated",
 })(unauthFunc)
 
 // unauthenticated ApiView
 @ApiView({
+  unauthorized: true,
   path: "/unauthView",
 })
 export class UnAuthView extends ApiViewBase {}

--- a/src/test/sampleApp.ts
+++ b/src/test/sampleApp.ts
@@ -77,3 +77,16 @@ Lambda({
   memorySize: 384,
   schedule: Schedule.rate(Duration.minutes(10)),
 })(scheduledFunc)
+
+// unauthenticated route
+export const unauthFunc = () => console.log("does not require authentication")
+Lambda({
+  unauthenticated: true,
+  path: "/unauthenticated",
+})(unauthFunc)
+
+// unauthenticated ApiView
+@ApiView({
+  path: "/unauthView",
+})
+export class UnAuthView extends ApiViewBase {}

--- a/src/test/sampleApp.ts
+++ b/src/test/sampleApp.ts
@@ -50,6 +50,7 @@ export async function topSongsHandler(event: ApiEvent) {
 Lambda({
   path: "/top-songs",
   methods: [HttpMethod.PUT],
+  authorizationScopes: ["charts:read"],
   memorySize: 384,
   environment: {
     LOG_LEVEL: "WARN",


### PR DESCRIPTION
Problem: if I set a default authorizer (e.g. Cognito JWT) for my `HttpApi`, I need to be able to disable it for certain routes such as "login".

Solution: add an `unauthorized` flag to function/view metadata. This explicitly sets the `None` authorizer as described [here](https://docs.aws.amazon.com/cdk/api/latest/docs/aws-apigatewayv2-authorizers-readme.html#route-authorization).

If set, it explicitly disables authorization for a route.

