### PR TITLE
No more magic verb routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,11 @@ import { ApiView, SubRoute, ApiEvent, ApiResponse, ApiViewBase, apiViewHandler }
   bundling: { minify: true, metafile: true, sourceMap: true },
 })
 export class AlbumApi extends ApiViewBase {
-  // define POST handler
-  post = async () => "Created new album"
+  // define POST /album handler
+  @SubRoute({ methods: [HttpMethod.POST] })
+  async post() {
+    return "Created new album"
+  }
 
   // custom endpoint in the view
   // routes to the ApiView function

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jetkit/cdk",
-  "version": "1.115.14",
+  "version": "1.115.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@jetkit/cdk",
-      "version": "1.115.14",
+      "version": "1.115.15",
       "license": "MIT",
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2": "1.115.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jetkit/cdk",
-  "version": "1.115.13",
+  "version": "1.115.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@jetkit/cdk",
-      "version": "1.115.13",
+      "version": "1.115.14",
       "license": "MIT",
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2": "1.115.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jetkit/cdk",
-  "version": "1.115.12",
+  "version": "1.115.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@jetkit/cdk",
-      "version": "1.115.12",
+      "version": "1.115.13",
       "license": "MIT",
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2": "1.115.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,8 @@
         "convict": "^6.1.0",
         "deepmerge": "^4.2.2",
         "is-plain-object": "^2.0.4",
-        "reflect-metadata": "^0.1.13"
+        "reflect-metadata": "^0.1.13",
+        "slugify": "^1.6.0"
       },
       "devDependencies": {
         "@aws-cdk/assert": "1.115.0",
@@ -14015,6 +14016,14 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/slugify": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.0.tgz",
+      "integrity": "sha512-FkMq+MQc5hzYgM86nLuHI98Acwi3p4wX+a5BO9Hhw4JdK4L7WueIiZ4tXEobImPqBz2sVcV0+Mu3GRB30IGang==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/snapdragon": {
       "version": "0.8.2",
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
@@ -26428,6 +26437,11 @@
           "dev": true
         }
       }
+    },
+    "slugify": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.0.tgz",
+      "integrity": "sha512-FkMq+MQc5hzYgM86nLuHI98Acwi3p4wX+a5BO9Hhw4JdK4L7WueIiZ4tXEobImPqBz2sVcV0+Mu3GRB30IGang=="
     },
     "snapdragon": {
       "version": "0.8.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,8 +33,8 @@
         "@aws-cdk/assert": "1.115.0",
         "@aws-cdk/core": "1.115.0",
         "@babel/plugin-proposal-decorators": "^7.13.15",
-        "@prisma/client": "^2.27.0",
-        "@prisma/migrate": "^2.27.0",
+        "@prisma/client": "^2.28.0",
+        "@prisma/migrate": "^2.28.0",
         "@ts-morph/bootstrap": "^0.9.1",
         "@tsconfig/node14": "^1.0.0",
         "@types/aws-lambda": "^8.10.75",
@@ -49,7 +49,7 @@
         "jest": "^26.4.2",
         "lint-staged": "^10.5.4",
         "prettier": "^2.2.1",
-        "prisma": "^2.27.0",
+        "prisma": "^2.28.0",
         "simple-markdown": "^0.7.3",
         "source-map-support": "^0.5.16",
         "ts-jest": "^26.2.0",
@@ -58,9 +58,9 @@
         "typescript": "^4.2.4"
       },
       "peerDependencies": {
-        "@prisma/client": "^2.27.0",
-        "@prisma/migrate": "^2.27.0",
-        "prisma": "^2.27.0"
+        "@prisma/client": "^2.28.0",
+        "@prisma/migrate": "^2.28.0",
+        "prisma": "^2.28.0"
       },
       "peerDependenciesMeta": {
         "@prisma/client": {
@@ -3817,13 +3817,13 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-2.27.0.tgz",
-      "integrity": "sha512-Sh2b1M8MGbOHbwG1FEqdWTUCrEX3p7gt2e7gpaBWou8yTIJvP1UZ4YlHgpuUcR1q4pEIR/JTZJeQk2l4iDyRBQ==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-2.28.0.tgz",
+      "integrity": "sha512-iwdxpy0Nz8N40MnhdlRvhZOBk8+GawpEsY5FU8Tfw1k9rvIeTAi+wBHrqhY8bXq6pneZkzrdQ1Hj3tqkrbRmoQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines-version": "2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb"
+        "@prisma/engines-version": "2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27"
       },
       "engines": {
         "node": ">=12.2"
@@ -3842,6 +3842,7 @@
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-2.27.0.tgz",
       "integrity": "sha512-Et01S4RoLnQP9u547dCp74aSnLWTu0akfBCzF4zQZsbEdw7wXLttrcvbcYKr+KhpfF5Xu291UP/Kaxg0aj8o4w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "debug": "4.3.2",
         "ms": "^2.1.3"
@@ -3851,7 +3852,8 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@prisma/engine-core": {
       "version": "2.27.0",
@@ -4002,12 +4004,13 @@
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb.tgz",
       "integrity": "sha512-AIbIhAxmd2CHZO5XzQTPrfk+Tp/5eoNoSledOG3yc6Dk97siLvnBuSEv7prggUbedCufDwZLAvwxV4PEw3zOlQ==",
       "dev": true,
-      "hasInstallScript": true
+      "hasInstallScript": true,
+      "peer": true
     },
     "node_modules/@prisma/engines-version": {
-      "version": "2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb.tgz",
-      "integrity": "sha512-pwOsYdzw8+cwKlUrCzasiRh96RhNuJ/QcKr0HwjxxlUWTmbEayDKjqRRz5fsUYIpSv5fW1B3SsbzHOqVtFZ6XQ==",
+      "version": "2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27.tgz",
+      "integrity": "sha512-BWTvF1mGxjG8EtG215uhxdeW5Uf5aiH4xhfzcFPFC3Ux5BdEM1uEBrLIixX67mI+ZNhqNZSBPf0DSf2I1IsaZw==",
       "dev": true
     },
     "node_modules/@prisma/fetch-engine": {
@@ -4271,6 +4274,7 @@
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb.tgz",
       "integrity": "sha512-N+akWuGHmgCaTfnD4YUum57wd4+GfOvKiTYYIMY2CIEJbxvFw/GF9v8rozl3WRZPgL+Hx3D0ZPB8E4NgvaLy0g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@prisma/debug": "2.26.0"
       }
@@ -4280,6 +4284,7 @@
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-2.26.0.tgz",
       "integrity": "sha512-dBZPmxGKXP0VhDpKgpsFM3NhjFZZmP09MKRgV3oWfZmU+X1uA+crVscrajfZsOP0T6lbP1FCDLkFEEGyNCyuFA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "debug": "4.3.2",
         "ms": "^2.1.3"
@@ -4289,16 +4294,17 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@prisma/migrate": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@prisma/migrate/-/migrate-2.27.0.tgz",
-      "integrity": "sha512-c9mdCKSkPFPPKn4+aA5hvHARD6D5klSmft+S489o8dT6qKfglCUQZQU+eD/Jh8uj8cHEhjZqL4VrsClJG/xe3A==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/@prisma/migrate/-/migrate-2.28.0.tgz",
+      "integrity": "sha512-vWE8OSKDPIlfW8bJU98xm11s8nKtve77M7N8oJlktYL8pENHnSYoWcDynq/RZcZlf0Zb74OOmOJ7Qh6/WBO3DA==",
       "dev": true,
       "dependencies": {
-        "@prisma/debug": "2.27.0",
-        "@prisma/get-platform": "2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb",
+        "@prisma/debug": "2.28.0",
+        "@prisma/get-platform": "2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27",
         "@sindresorhus/slugify": "^1.1.0",
         "execa": "^5.0.0",
         "global-dirs": "^3.0.0",
@@ -4316,6 +4322,35 @@
       "peerDependencies": {
         "@prisma/generator-helper": "*",
         "@prisma/sdk": "*"
+      }
+    },
+    "node_modules/@prisma/migrate/node_modules/@prisma/debug": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-2.28.0.tgz",
+      "integrity": "sha512-SKihAtTPDqfm/iyLVs5xf1uLu4Ev+zcFLc8vdiGofpHTkeiu3qU1OSDPnrQ0nwn0IJsp3SeRbV0NRWTwL5Z71w==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4.3.2",
+        "ms": "^2.1.3"
+      }
+    },
+    "node_modules/@prisma/migrate/node_modules/@prisma/get-platform": {
+      "version": "2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27.tgz",
+      "integrity": "sha512-OdTubLy4lVRYNvF3N9eODWxLxUhgh2oapDVvdMO3YmHQSeYQzzHHhYHBKoUY9zpCCAbAPBik+YIXgimJp3lqQQ==",
+      "dev": true,
+      "dependencies": {
+        "@prisma/debug": "2.27.0"
+      }
+    },
+    "node_modules/@prisma/migrate/node_modules/@prisma/get-platform/node_modules/@prisma/debug": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-2.27.0.tgz",
+      "integrity": "sha512-Et01S4RoLnQP9u547dCp74aSnLWTu0akfBCzF4zQZsbEdw7wXLttrcvbcYKr+KhpfF5Xu291UP/Kaxg0aj8o4w==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4.3.2",
+        "ms": "^2.1.3"
       }
     },
     "node_modules/@prisma/migrate/node_modules/execa": {
@@ -4361,6 +4396,12 @@
       "engines": {
         "node": ">=10.17.0"
       }
+    },
+    "node_modules/@prisma/migrate/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "node_modules/@prisma/sdk": {
       "version": "2.27.0",
@@ -13130,13 +13171,13 @@
       "peer": true
     },
     "node_modules/prisma": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-2.27.0.tgz",
-      "integrity": "sha512-/3H9C+IPlJmY5KArhfKHMpxKXqcZIBZ+LjM1b5FxvLCGQkq/mRC96SpHcKcLtiYgftNAX13nvlxg+cBw9Dbe8Q==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-2.28.0.tgz",
+      "integrity": "sha512-f83KPLy3xk07KMY4e5otNwP2I+GsdftjOfu3e8snXylnyAC1oEpRZNe7rmONr0vAI+Qgz3LFRArhWUE/dFjKIA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb"
+        "@prisma/engines": "2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27"
       },
       "bin": {
         "prisma": "build/index.js",
@@ -13145,6 +13186,13 @@
       "engines": {
         "node": ">=12.2"
       }
+    },
+    "node_modules/prisma/node_modules/@prisma/engines": {
+      "version": "2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27.tgz",
+      "integrity": "sha512-r3/EnwKjbu2qz13I98hPQQdeFrOEcwdjlrB9CcoSoqRCjSHLnpdVMUvRfYuRKIoEF7p941R7/Fov0/CxOLF/MQ==",
+      "dev": true,
+      "hasInstallScript": true
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
@@ -18354,12 +18402,12 @@
       }
     },
     "@prisma/client": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-2.27.0.tgz",
-      "integrity": "sha512-Sh2b1M8MGbOHbwG1FEqdWTUCrEX3p7gt2e7gpaBWou8yTIJvP1UZ4YlHgpuUcR1q4pEIR/JTZJeQk2l4iDyRBQ==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-2.28.0.tgz",
+      "integrity": "sha512-iwdxpy0Nz8N40MnhdlRvhZOBk8+GawpEsY5FU8Tfw1k9rvIeTAi+wBHrqhY8bXq6pneZkzrdQ1Hj3tqkrbRmoQ==",
       "dev": true,
       "requires": {
-        "@prisma/engines-version": "2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb"
+        "@prisma/engines-version": "2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27"
       }
     },
     "@prisma/debug": {
@@ -18367,6 +18415,7 @@
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-2.27.0.tgz",
       "integrity": "sha512-Et01S4RoLnQP9u547dCp74aSnLWTu0akfBCzF4zQZsbEdw7wXLttrcvbcYKr+KhpfF5Xu291UP/Kaxg0aj8o4w==",
       "dev": true,
+      "peer": true,
       "requires": {
         "debug": "4.3.2",
         "ms": "^2.1.3"
@@ -18376,7 +18425,8 @@
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-          "dev": true
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -18494,12 +18544,13 @@
       "version": "2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb.tgz",
       "integrity": "sha512-AIbIhAxmd2CHZO5XzQTPrfk+Tp/5eoNoSledOG3yc6Dk97siLvnBuSEv7prggUbedCufDwZLAvwxV4PEw3zOlQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "@prisma/engines-version": {
-      "version": "2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb.tgz",
-      "integrity": "sha512-pwOsYdzw8+cwKlUrCzasiRh96RhNuJ/QcKr0HwjxxlUWTmbEayDKjqRRz5fsUYIpSv5fW1B3SsbzHOqVtFZ6XQ==",
+      "version": "2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27.tgz",
+      "integrity": "sha512-BWTvF1mGxjG8EtG215uhxdeW5Uf5aiH4xhfzcFPFC3Ux5BdEM1uEBrLIixX67mI+ZNhqNZSBPf0DSf2I1IsaZw==",
       "dev": true
     },
     "@prisma/fetch-engine": {
@@ -18710,6 +18761,7 @@
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb.tgz",
       "integrity": "sha512-N+akWuGHmgCaTfnD4YUum57wd4+GfOvKiTYYIMY2CIEJbxvFw/GF9v8rozl3WRZPgL+Hx3D0ZPB8E4NgvaLy0g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@prisma/debug": "2.26.0"
       },
@@ -18719,6 +18771,7 @@
           "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-2.26.0.tgz",
           "integrity": "sha512-dBZPmxGKXP0VhDpKgpsFM3NhjFZZmP09MKRgV3oWfZmU+X1uA+crVscrajfZsOP0T6lbP1FCDLkFEEGyNCyuFA==",
           "dev": true,
+          "peer": true,
           "requires": {
             "debug": "4.3.2",
             "ms": "^2.1.3"
@@ -18728,18 +18781,19 @@
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-          "dev": true
+          "dev": true,
+          "peer": true
         }
       }
     },
     "@prisma/migrate": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@prisma/migrate/-/migrate-2.27.0.tgz",
-      "integrity": "sha512-c9mdCKSkPFPPKn4+aA5hvHARD6D5klSmft+S489o8dT6qKfglCUQZQU+eD/Jh8uj8cHEhjZqL4VrsClJG/xe3A==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/@prisma/migrate/-/migrate-2.28.0.tgz",
+      "integrity": "sha512-vWE8OSKDPIlfW8bJU98xm11s8nKtve77M7N8oJlktYL8pENHnSYoWcDynq/RZcZlf0Zb74OOmOJ7Qh6/WBO3DA==",
       "dev": true,
       "requires": {
-        "@prisma/debug": "2.27.0",
-        "@prisma/get-platform": "2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb",
+        "@prisma/debug": "2.28.0",
+        "@prisma/get-platform": "2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27",
         "@sindresorhus/slugify": "^1.1.0",
         "execa": "^5.0.0",
         "global-dirs": "^3.0.0",
@@ -18755,6 +18809,37 @@
         "strip-indent": "^3.0.0"
       },
       "dependencies": {
+        "@prisma/debug": {
+          "version": "2.28.0",
+          "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-2.28.0.tgz",
+          "integrity": "sha512-SKihAtTPDqfm/iyLVs5xf1uLu4Ev+zcFLc8vdiGofpHTkeiu3qU1OSDPnrQ0nwn0IJsp3SeRbV0NRWTwL5Z71w==",
+          "dev": true,
+          "requires": {
+            "debug": "4.3.2",
+            "ms": "^2.1.3"
+          }
+        },
+        "@prisma/get-platform": {
+          "version": "2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27",
+          "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27.tgz",
+          "integrity": "sha512-OdTubLy4lVRYNvF3N9eODWxLxUhgh2oapDVvdMO3YmHQSeYQzzHHhYHBKoUY9zpCCAbAPBik+YIXgimJp3lqQQ==",
+          "dev": true,
+          "requires": {
+            "@prisma/debug": "2.27.0"
+          },
+          "dependencies": {
+            "@prisma/debug": {
+              "version": "2.27.0",
+              "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-2.27.0.tgz",
+              "integrity": "sha512-Et01S4RoLnQP9u547dCp74aSnLWTu0akfBCzF4zQZsbEdw7wXLttrcvbcYKr+KhpfF5Xu291UP/Kaxg0aj8o4w==",
+              "dev": true,
+              "requires": {
+                "debug": "4.3.2",
+                "ms": "^2.1.3"
+              }
+            }
+          }
+        },
         "execa": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -18782,6 +18867,12 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
           "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         }
       }
@@ -25776,12 +25867,20 @@
       "peer": true
     },
     "prisma": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-2.27.0.tgz",
-      "integrity": "sha512-/3H9C+IPlJmY5KArhfKHMpxKXqcZIBZ+LjM1b5FxvLCGQkq/mRC96SpHcKcLtiYgftNAX13nvlxg+cBw9Dbe8Q==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-2.28.0.tgz",
+      "integrity": "sha512-f83KPLy3xk07KMY4e5otNwP2I+GsdftjOfu3e8snXylnyAC1oEpRZNe7rmONr0vAI+Qgz3LFRArhWUE/dFjKIA==",
       "dev": true,
       "requires": {
-        "@prisma/engines": "2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb"
+        "@prisma/engines": "2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27"
+      },
+      "dependencies": {
+        "@prisma/engines": {
+          "version": "2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27",
+          "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27.tgz",
+          "integrity": "sha512-r3/EnwKjbu2qz13I98hPQQdeFrOEcwdjlrB9CcoSoqRCjSHLnpdVMUvRfYuRKIoEF7p941R7/Fov0/CxOLF/MQ==",
+          "dev": true
+        }
       }
     },
     "process-nextick-args": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jetkit/cdk",
-  "version": "1.115.8",
+  "version": "1.115.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@jetkit/cdk",
-      "version": "1.115.8",
+      "version": "1.115.12",
       "license": "MIT",
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2": "1.115.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetkit/cdk",
-  "version": "1.115.14",
+  "version": "1.115.15",
   "description": "Cloud-native serverless anti-framework",
   "types": "build/esm/index.d.ts",
   "main": "build/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "convict": "^6.1.0",
     "deepmerge": "^4.2.2",
     "is-plain-object": "^2.0.4",
-    "reflect-metadata": "^0.1.13"
+    "reflect-metadata": "^0.1.13",
+    "slugify": "^1.6.0"
   },
   "peerDependenciesMeta": {
     "prisma": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetkit/cdk",
-  "version": "1.115.8",
+  "version": "1.115.12",
   "description": "Cloud-native serverless anti-framework",
   "types": "build/esm/index.d.ts",
   "main": "build/cjs/index.js",
@@ -21,7 +21,8 @@
     "prepare": "husky install",
     "prepack": "npm run build",
     "rel:patch": "npm version patch && npm publish",
-    "rel:minor": "npm version minor && npm publish"
+    "rel:minor": "npm version minor && npm publish",
+    "rel:next": "npm version patch && npm publish --tag next"
   },
   "author": "JetBridge Software Inc.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "@aws-cdk/assert": "1.115.0",
     "@aws-cdk/core": "1.115.0",
     "@babel/plugin-proposal-decorators": "^7.13.15",
-    "@prisma/client": "^2.27.0",
-    "@prisma/migrate": "^2.27.0",
+    "@prisma/client": "^2.28.0",
+    "@prisma/migrate": "^2.28.0",
     "@ts-morph/bootstrap": "^0.9.1",
     "@tsconfig/node14": "^1.0.0",
     "@types/aws-lambda": "^8.10.75",
@@ -46,7 +46,7 @@
     "jest": "^26.4.2",
     "lint-staged": "^10.5.4",
     "prettier": "^2.2.1",
-    "prisma": "^2.27.0",
+    "prisma": "^2.28.0",
     "simple-markdown": "^0.7.3",
     "source-map-support": "^0.5.16",
     "ts-jest": "^26.2.0",
@@ -87,9 +87,9 @@
     }
   },
   "peerDependencies": {
-    "@prisma/client": "^2.27.0",
-    "@prisma/migrate": "^2.27.0",
-    "prisma": "^2.27.0"
+    "@prisma/client": "^2.28.0",
+    "@prisma/migrate": "^2.28.0",
+    "prisma": "^2.28.0"
   },
   "lint-staged": {
     "*.{js,css,md}": "prettier --write"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetkit/cdk",
-  "version": "1.115.12",
+  "version": "1.115.13",
   "description": "Cloud-native serverless anti-framework",
   "types": "build/esm/index.d.ts",
   "main": "build/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetkit/cdk",
-  "version": "1.115.13",
+  "version": "1.115.14",
   "description": "Cloud-native serverless anti-framework",
   "types": "build/esm/index.d.ts",
   "main": "build/cjs/index.js",

--- a/src/api/base.test.ts
+++ b/src/api/base.test.ts
@@ -36,7 +36,7 @@ describe("ApiViewBase", () => {
   const view = new AlbumApi()
 
   describe("findHandler", () => {
-    it("locates handler method based on request verb", () => {
+    it("locates handler method based on method", () => {
       const request = makeApiEvent({
         method: HttpMethod.POST,
         path: "/album",
@@ -77,7 +77,7 @@ describe("ApiViewBase", () => {
       expect(anyView.findHandler(request as ApiEvent)).toEqual(anyView.handler)
     })
 
-    it("locates appropriate class route with any method", () => {
+    it("fails to locate class route with any method", () => {
       @ApiView({
         path: "/proxy",
       })
@@ -90,7 +90,7 @@ describe("ApiViewBase", () => {
       })
 
       const anyView = new AnyApi()
-      expect(anyView.findHandler(request as ApiEvent)).toEqual(anyView.post)
+      expect(anyView.findHandler(request as ApiEvent)).toEqual(undefined)
     })
 
     it("locates no method based on request if no match on routeKey", () => {

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -10,7 +10,6 @@ import {
   ISubRouteApiMetadata,
   MetadataTarget,
 } from "../metadata"
-import { safeHas } from "../util/type"
 
 /**
  * JetKit supports using API View classes to organize your RESTful endpoints.
@@ -60,6 +59,10 @@ async function raiseNotAllowed(event: ApiEvent) {
  *
  */
 export class ApiViewBase {
+  getMetadata(): IApiViewClassMetadata | undefined {
+    return getApiViewMetadata(this.constructor as MetadataTarget)
+  }
+
   /**
    * Look up appropriate method to handle an incoming request for this view.
    *
@@ -72,7 +75,7 @@ export class ApiViewBase {
     const routeKey = event.routeKey
     // get metadata
     const apiViewClass = this.constructor as MetadataTarget
-    const viewMeta = getApiViewMetadata(apiViewClass)
+    const viewMeta = this.getMetadata()
     const subRouteMetaMap = getSubRouteMetadata(apiViewClass)
     if (!viewMeta) throw new Error(`Metadata for dispatch not found on API view ${apiViewClass}`)
     if (!viewMeta.path) return undefined

--- a/src/cdk/api/api.test.ts
+++ b/src/cdk/api/api.test.ts
@@ -2,7 +2,7 @@ import "@aws-cdk/assert/jest"
 import { HttpApi } from "@aws-cdk/aws-apigatewayv2"
 import { Stack } from "@aws-cdk/core"
 import * as path from "path"
-import { ApiView, JetKitLambdaFunction } from "./api"
+import { ApiFunction, JetKitLambdaFunction } from "./api"
 
 const entry = path.join(__dirname, "..", "..", "test", "sampleApp.ts")
 
@@ -20,7 +20,7 @@ describe("ApiView", () => {
   it("doesn't create a route if no methods", () => {
     const addRoutesSpy = jest.spyOn(httpApi, "addRoutes")
 
-    new ApiView(stack, "V", { handlerFunction, httpApi, methods: [] })
+    new ApiFunction(stack, "V", { handlerFunction, httpApi, methods: [] })
 
     addRoutesSpy.mockReturnValue([])
     expect(addRoutesSpy).not.toHaveBeenCalled()

--- a/src/cdk/api/api.test.ts
+++ b/src/cdk/api/api.test.ts
@@ -1,5 +1,5 @@
 import "@aws-cdk/assert/jest"
-import { HttpApi, HttpMethod } from "@aws-cdk/aws-apigatewayv2"
+import { HttpApi } from "@aws-cdk/aws-apigatewayv2"
 import { Stack } from "@aws-cdk/core"
 import * as path from "path"
 import { ApiView, JetKitLambdaFunction } from "./api"
@@ -24,53 +24,5 @@ describe("ApiView", () => {
 
     addRoutesSpy.mockReturnValue([])
     expect(addRoutesSpy).not.toHaveBeenCalled()
-  })
-
-  it("creates a route with any method", () => {
-    const addRoutesSpy = jest.spyOn(httpApi, "addRoutes")
-
-    new ApiView(stack, "V1", {
-      path: "/x",
-      httpApi,
-      handlerFunction,
-      methods: [],
-    })
-
-    const view = new ApiView(stack, "V2", {
-      path: "/a",
-      httpApi,
-      handlerFunction,
-      // methods defaults to [ANY]
-    })
-
-    expect(addRoutesSpy).toHaveBeenCalledWith({
-      path: "/a",
-      methods: [HttpMethod.ANY],
-      integration: view.lambdaApiIntegration,
-    })
-  })
-
-  it("creates a route with methods", () => {
-    const addRoutesSpy = jest.spyOn(httpApi, "addRoutes")
-
-    new ApiView(stack, "V1", {
-      path: "/x",
-      httpApi,
-      handlerFunction,
-      methods: [],
-    })
-
-    const view = new ApiView(stack, "V2", {
-      path: "/a",
-      httpApi,
-      handlerFunction,
-      methods: [HttpMethod.GET, HttpMethod.POST],
-    })
-
-    expect(addRoutesSpy).toHaveBeenCalledWith({
-      path: "/a",
-      methods: [HttpMethod.GET, HttpMethod.POST],
-      integration: view.lambdaApiIntegration,
-    })
   })
 })

--- a/src/cdk/api/api.ts
+++ b/src/cdk/api/api.ts
@@ -1,7 +1,7 @@
-import { HttpApi, HttpMethod, PayloadFormatVersion } from "@aws-cdk/aws-apigatewayv2"
+import { HttpApi, HttpMethod, HttpNoneAuthorizer, PayloadFormatVersion } from "@aws-cdk/aws-apigatewayv2"
 import { LambdaProxyIntegration } from "@aws-cdk/aws-apigatewayv2-integrations"
-import { NodejsFunction } from "@aws-cdk/aws-lambda-nodejs"
 import { CfnOutput, Construct } from "@aws-cdk/core"
+import { IFunctionMetadataBase } from "../../metadata"
 import { FunctionOptions } from "../generator"
 import { Node14Func as JetKitLambdaFunction, Node14FuncProps as JetKitLambdaFunctionProps } from "../lambda/node14func"
 
@@ -13,24 +13,15 @@ export { JetKitLambdaFunction, JetKitLambdaFunctionProps }
 export interface ApiConfig extends FunctionOptions, IEndpoint {}
 
 export interface ApiProps extends ApiConfig {
-  handlerFunction: NodejsFunction
+  handlerFunction: JetKitLambdaFunction
 }
 
-export interface IEndpoint {
+export interface IEndpoint
+  extends Pick<IFunctionMetadataBase, "path" | "methods" | "unauthorized" | "authorizationScopes"> {
   /**
    * API Gateway HTTP API
    */
   httpApi: HttpApi
-
-  /**
-   * Route
-   */
-  path?: string
-
-  /**
-   * Enabled {@link HttpMethod}s for route
-   */
-  methods?: HttpMethod[]
 }
 
 let routeOutputId = 1
@@ -39,7 +30,7 @@ export interface IAddRoutes extends IEndpoint {
   lambdaApiIntegration: LambdaProxyIntegration
 }
 export abstract class ApiViewMixin extends Construct {
-  addRoutes({ methods, path = "/", httpApi, lambdaApiIntegration }: IAddRoutes) {
+  addRoutes({ methods, path = "/", httpApi, lambdaApiIntegration, unauthorized, ...rest }: IAddRoutes) {
     methods = methods || [HttpMethod.ANY]
 
     if (!methods.length) return
@@ -49,6 +40,8 @@ export abstract class ApiViewMixin extends Construct {
       path,
       methods,
       integration: lambdaApiIntegration,
+      ...rest,
+      ...(unauthorized ? { authorizer: new HttpNoneAuthorizer() } : {}),
     })
 
     // output the route for easily seeing at a glance what routes are generated
@@ -68,12 +61,11 @@ export abstract class ApiViewMixin extends Construct {
 export class ApiView extends ApiViewMixin implements IEndpoint {
   httpApi: HttpApi
   path?: string
-  methods?: HttpMethod[]
 
   handlerFunction: JetKitLambdaFunction
   lambdaApiIntegration: LambdaProxyIntegration
 
-  constructor(scope: Construct, id: string, { httpApi, methods, path = "/", handlerFunction }: ApiProps) {
+  constructor(scope: Construct, id: string, { httpApi, path = "/", handlerFunction }: ApiProps) {
     super(scope, id)
 
     // lambda handler
@@ -87,11 +79,5 @@ export class ApiView extends ApiViewMixin implements IEndpoint {
 
     this.httpApi = httpApi
     this.path = path
-    const routes: IAddRoutes = { httpApi, path, lambdaApiIntegration: this.lambdaApiIntegration }
-    if (methods) {
-      this.methods = methods
-      routes.methods = methods
-    }
-    this.addRoutes(routes)
   }
 }

--- a/src/cdk/api/api.ts
+++ b/src/cdk/api/api.ts
@@ -58,14 +58,15 @@ export abstract class ApiViewMixin extends Construct {
  *
  * @category Construct
  */
-export class ApiView extends ApiViewMixin implements IEndpoint {
+export class ApiFunction extends ApiViewMixin implements IEndpoint {
   httpApi: HttpApi
   path?: string
+  methods?: HttpMethod[]
 
   handlerFunction: JetKitLambdaFunction
   lambdaApiIntegration: LambdaProxyIntegration
 
-  constructor(scope: Construct, id: string, { httpApi, path = "/", handlerFunction }: ApiProps) {
+  constructor(scope: Construct, id: string, { httpApi, path = "/", methods, handlerFunction, ...rest }: ApiProps) {
     super(scope, id)
 
     // lambda handler
@@ -77,7 +78,15 @@ export class ApiView extends ApiViewMixin implements IEndpoint {
       payloadFormatVersion: PayloadFormatVersion.VERSION_2_0,
     })
 
+    // construct route params
+    const routes: IAddRoutes = { httpApi, path, lambdaApiIntegration: this.lambdaApiIntegration, ...rest }
+    if (methods) routes.methods = methods
+    this.methods = methods
+
     this.httpApi = httpApi
     this.path = path
+
+    // create routes
+    this.addRoutes(routes)
   }
 }

--- a/src/cdk/api/subRoute.ts
+++ b/src/cdk/api/subRoute.ts
@@ -30,8 +30,8 @@ export class SubRouteApi extends ApiViewMixin {
     path = parentPath + (path || "")
 
     // inherit parent `unauthorized` and `authorizationScopes`
-    if (typeof unauthorized === "undefined") unauthorized ||= parentApiMeta?.unauthorized
-    if (typeof authorizationScopes === "undefined") authorizationScopes ||= parentApiMeta?.authorizationScopes
+    if (unauthorized === undefined) unauthorized ||= parentApiMeta?.unauthorized
+    if (authorizationScopes === undefined) authorizationScopes ||= parentApiMeta?.authorizationScopes
 
     // add our route to the existing parent API's handler function
     // it will know how to find our method and call it

--- a/src/cdk/api/subRoute.ts
+++ b/src/cdk/api/subRoute.ts
@@ -1,31 +1,31 @@
 import { Construct } from "@aws-cdk/core"
 import { ApiView, ApiViewMixin, IEndpoint } from "./api"
 
-export interface ISubRouteApiProps extends Omit<IEndpoint, "httpApi"> {
+export interface SubRouteApiProps extends Omit<IEndpoint, "httpApi"> {
   parentApi: ApiView
-  path: string
+  path?: string
 }
 
 /**
- * Route chained off an existing route and function.
+ * Route chained off an existing path and function.
  *
  * @category Construct
  */
 export class SubRouteApi extends ApiViewMixin {
-  constructor(scope: Construct, id: string, { methods, parentApi, path }: ISubRouteApiProps) {
+  constructor(scope: Construct, id: string, { parentApi, path, ...rest }: SubRouteApiProps) {
     super(scope, id)
 
     // join parent path and our path together
-    if (!path.startsWith("/")) path = `/${path}`
-    path = parentApi.path + path
+    if (path && !path.startsWith("/")) path = `/${path}`
+    path = parentApi.path + (path || "")
 
     // add our route to the existing parent API's handler function
     // it will know how to find our method and call it
     this.addRoutes({
       path,
-      methods,
       httpApi: parentApi.httpApi,
       lambdaApiIntegration: parentApi.lambdaApiIntegration,
+      ...rest,
     })
   }
 }

--- a/src/cdk/generator.test.ts
+++ b/src/cdk/generator.test.ts
@@ -133,13 +133,6 @@ describe("@ApiView construct generation", () => {
       methods: [],
     })
 
-    new ApiFunction(stack, "V2", {
-      path: "/a",
-      httpApi,
-      handlerFunction,
-      // methods defaults to [ANY]
-    })
-
     expect(addRoutesSpy).not.toHaveBeenCalled()
   })
 })

--- a/src/cdk/generator.test.ts
+++ b/src/cdk/generator.test.ts
@@ -9,7 +9,16 @@ import { NodejsFunction } from "@aws-cdk/aws-lambda-nodejs"
 import { Duration, Stack } from "@aws-cdk/core"
 import * as path from "path"
 import { ApiViewConstruct, ResourceGeneratorConstruct } from ".."
-import { AlbumApi, scheduledFunc, topSongsFuncInner, topSongsHandler, unauthFunc, UnAuthView } from "../test/sampleApp"
+import {
+  AlbumApi,
+  authFunc,
+  AuthScopeView,
+  scheduledFunc,
+  topSongsFuncInner,
+  topSongsHandler,
+  unauthFunc,
+  UnAuthView,
+} from "../test/sampleApp"
 import { ApiView, JetKitLambdaFunction } from "./api/api"
 import { Node14Func } from "./lambda/node14func"
 
@@ -253,7 +262,6 @@ describe("Lambda() construct generation of APIs", () => {
   it("generates endpoints for standalone functions", () => {
     expect(stack).toHaveResource("AWS::ApiGatewayV2::Route", {
       RouteKey: "PUT /top-songs",
-      AuthorizationScopes: ["charts:read"],
     })
     expect(stack).toHaveResource("AWS::Lambda::Function", {
       Environment: {
@@ -328,6 +336,38 @@ describe("Authorization", () => {
     expect(stack).toHaveResource("AWS::ApiGatewayV2::Route", {
       RouteKey: "ANY /unauthView",
       AuthorizationType: "NONE",
+    })
+  })
+
+  it("requires authentication scopes for function route", () => {
+    new ResourceGeneratorConstruct(stack, "Gen", {
+      httpApi,
+      resources: [authFunc],
+    })
+
+    expect(stack).toHaveResource("AWS::ApiGatewayV2::Route", {
+      AuthorizationScopes: ["charts:write"],
+      RouteKey: "ANY /authenticated",
+      AuthorizationType: "CUSTOM",
+      AuthorizerId: {
+        Ref: stringLike("APIdummy*"),
+      },
+    })
+  })
+
+  it("requires authentication scopes for ApiView", () => {
+    new ResourceGeneratorConstruct(stack, "Gen", {
+      httpApi,
+      resources: [AuthScopeView],
+    })
+
+    expect(stack).toHaveResource("AWS::ApiGatewayV2::Route", {
+      AuthorizationScopes: ["charts:read"],
+      RouteKey: "ANY /authView",
+      AuthorizationType: "CUSTOM",
+      AuthorizerId: {
+        Ref: stringLike("APIdummy*"),
+      },
     })
   })
 })

--- a/src/cdk/generator.test.ts
+++ b/src/cdk/generator.test.ts
@@ -90,18 +90,11 @@ describe("@ApiView construct generation", () => {
     expect(found?.name).toEqual("AlbumApi")
   })
 
-  it("can find APIView function by cctor", () => {
+  it("can find APIView function by ctor", () => {
     const found = generator.getFunction({ ctor: AlbumApi })
     expect(found).toBeTruthy()
     expect(found).toBeInstanceOf(Node14Func)
     expect(found?.name).toEqual("AlbumApi")
-  })
-
-  it("generates APIGW routes", () => {
-    // should have routes
-    expect(stack).toHaveResource("AWS::ApiGatewayV2::Route", {
-      RouteKey: "ANY /album",
-    })
   })
 
   it("creates lambda handler", () => {
@@ -129,7 +122,7 @@ describe("@ApiView construct generation", () => {
     expect(generator.functionOptions?.entry).toBeFalsy()
   })
 
-  it("creates a route with any method", () => {
+  it("doesn't create routes for empty api view", () => {
     const entry = path.join(__dirname, "..", "test", "sampleApp.ts")
     const addRoutesSpy = jest.spyOn(httpApi, "addRoutes")
     const handlerFunction = new JetKitLambdaFunction(stack, "Func", { entry })
@@ -141,18 +134,14 @@ describe("@ApiView construct generation", () => {
       methods: [],
     })
 
-    const view = new ApiView(stack, "V2", {
+    new ApiView(stack, "V2", {
       path: "/a",
       httpApi,
       handlerFunction,
       // methods defaults to [ANY]
     })
 
-    expect(addRoutesSpy).toHaveBeenCalledWith({
-      path: "/a",
-      methods: [HttpMethod.ANY],
-      integration: view.lambdaApiIntegration,
-    })
+    expect(addRoutesSpy).not.toHaveBeenCalled()
   })
 })
 
@@ -183,9 +172,10 @@ describe("@SubRoute construct generation", () => {
       outputValue: "POST,DELETE /album/{albumId}/like",
     })
     expect(stack).toHaveOutput({
-      outputName: "GenClassAlbumApi1Route59A25E34B",
-      outputValue: "ANY /album",
+      outputName: "GenSubRoutepostRoute57A42D89F",
+      outputValue: "POST /album",
     })
+
     expect(stack).toHaveOutput({
       exportName: {
         "Fn::Join": [
@@ -334,7 +324,7 @@ describe("Authorization", () => {
     })
 
     expect(stack).toHaveResource("AWS::ApiGatewayV2::Route", {
-      RouteKey: "ANY /unauthView",
+      RouteKey: "GET /unauthView",
       AuthorizationType: "NONE",
     })
   })

--- a/src/cdk/generator.test.ts
+++ b/src/cdk/generator.test.ts
@@ -160,11 +160,11 @@ describe("@SubRoute construct generation", () => {
   })
   it("has route outputs", () => {
     expect(stack).toHaveOutput({
-      outputName: "GenSubRoutelikeRoute6CEDD760E",
+      outputName: "GenSRAlbumApilikeRoute6C6175CC5",
       outputValue: "POST,DELETE /album/{albumId}/like",
     })
     expect(stack).toHaveOutput({
-      outputName: "GenSubRoutepostRoute57A42D89F",
+      outputName: "GenSRAlbumApipostRoute5F0E8C334",
       outputValue: "POST /album",
     })
 

--- a/src/cdk/generator.ts
+++ b/src/cdk/generator.ts
@@ -309,7 +309,7 @@ export class ResourceGenerator extends Construct {
     // handled by the classes's handler
     const subRoutes = getSubRouteMetadata(resource)
     if (subRoutes) {
-      subRoutes.forEach((meta, subroutePath) => {
+      subRoutes.forEach((meta) => {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { path: metaPath, propertyKey, ...metaRest } = meta
 
@@ -317,7 +317,7 @@ export class ResourceGenerator extends Construct {
 
         // TODO: include parent api class name in id
         // TODO: do something with propertyKey and HandlerFunc
-        const path = metaPath || subroutePath
+        const path = metaPath
         new SubRouteApi(this, `SubRoute-${meta.propertyKey}`, {
           path,
           ...metaRest,

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export {
 } from "./cdk/generator"
 
 // convient AWS CDK utilities to have
-export { CorsHttpMethod } from "@aws-cdk/aws-apigatewayv2"
+export { CorsHttpMethod, HttpMethod } from "@aws-cdk/aws-apigatewayv2"
 export { Duration } from "@aws-cdk/core"
 
 // api

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,6 @@ export { ApiView, Lambda, SubRoute, IRouteProps, ISubRouteProps } from "./regist
 export {
   IFunctionMetadataBase as IApiMetadata,
   IApiViewClassMetadata,
-  ICrudApiMetadata,
   IFunctionMetadata,
   ISubRouteApiMetadata,
   MetadataTarget,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 export { JetKitCdkApp } from "./app/cdk"
 
 // cdk constructs
-export { ApiView as ApiViewConstruct, ApiProps as ApiViewConstructProps } from "./cdk/api/api"
+export { ApiFunction as ApiViewConstruct, ApiProps as ApiViewConstructProps } from "./cdk/api/api"
 export * from "./cdk/lambda/node14func"
 export * from "./cdk/lambda/prismaNodeFunction"
 export { DatabaseMigrationScript } from "./cdk/lambda/script/database/migration"

--- a/src/metadata.test.ts
+++ b/src/metadata.test.ts
@@ -21,14 +21,19 @@ describe("Metadata decorators", () => {
     it("stores metadata for subroutes", () => {
       // get meta
       const methodMeta = getSubRouteMetadata(AlbumApi)
-      const expectedMeta = {
+      expect(methodMeta.size).toBe(2)
+      expect(methodMeta.get("like")).toMatchObject({
         propertyKey: "like",
         HandlerFunc: AlbumApi.prototype.like,
         path: "/{albumId}/like",
         methods: [HttpMethod.POST, HttpMethod.DELETE],
-      }
-      expect(methodMeta.size).toBe(1)
-      expect(methodMeta.get("like")).toMatchObject(expectedMeta)
+      })
+      expect(methodMeta.get("post")).toMatchObject({
+        propertyKey: "post",
+        HandlerFunc: AlbumApi.prototype.post,
+        path: undefined,
+        methods: [HttpMethod.POST],
+      })
     })
   })
 

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -9,7 +9,7 @@ import { Schedule } from "@aws-cdk/aws-events"
 import "reflect-metadata"
 import { ApiHandler, ApiViewBase } from "./api/base"
 import { FunctionOptions } from "./cdk/generator"
-import { PossibleLambdaHandlers } from "./registry"
+import { ApiViewOpts, PossibleLambdaHandlers } from "./registry"
 
 /**
  * A class we can apply @ApiView to.
@@ -20,7 +20,6 @@ const JK_V2_METADATA_KEY = Symbol.for("jk:v2:metadata")
 
 // metadata map keys
 export const JK_V2_METADATA_API_VIEW_KEY = Symbol.for("jk:v2:metadata:api:view")
-export const JK_V2_METADATA_CRUD_API_KEY = Symbol.for("jk:v2:metadata:api:crud")
 // sub-route method inside a class
 export const JK_V2_METADATA_SUBROUTES_KEY = Symbol.for("jk:v2:metadata:subroutes")
 // standalone function
@@ -79,15 +78,7 @@ export interface IFunctionMetadata extends IFunctionMetadataBase {
 /**
  * APIView class.
  */
-export interface IApiViewClassMetadata extends IFunctionMetadataBase {
-  apiClass: MetadataTargetConstructor
-}
-
-/**
- * CRUD view.
- * Unused.
- */
-export interface ICrudApiMetadata extends IFunctionMetadataBase {
+export interface IApiViewClassMetadata extends ApiViewOpts {
   apiClass: MetadataTargetConstructor
 }
 
@@ -121,12 +112,6 @@ export const getApiViewMetadata = (cls: MetadataTarget): IApiViewClassMetadata |
   getMemberMetadata(cls, JK_V2_METADATA_API_VIEW_KEY)
 export const setApiViewMetadata = (cls: MetadataTarget, value: IApiViewClassMetadata) =>
   setMemberMetadata(cls, JK_V2_METADATA_API_VIEW_KEY, value)
-
-// CRUD API
-export const getCrudApiMetadata = (cls: MetadataTarget): ICrudApiMetadata | undefined =>
-  getMemberMetadata(cls, JK_V2_METADATA_CRUD_API_KEY)
-export const setCrudApiMetadata = (cls: MetadataTarget, value: ICrudApiMetadata) =>
-  setMemberMetadata(cls, JK_V2_METADATA_CRUD_API_KEY, value)
 
 // sub-routes
 export const getSubRouteMetadata = (target: MetadataTarget): ApiMetadataMap<ISubRouteApiMetadata> =>

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -4,7 +4,6 @@
 /**
  * Wrappers for getting/setting metadata on classes and class properties
  */
-import { HttpMethod, HttpRouteProps } from "@aws-cdk/aws-apigatewayv2"
 import { Schedule } from "@aws-cdk/aws-events"
 import "reflect-metadata"
 import { ApiHandler, ApiViewBase } from "./api/base"
@@ -21,7 +20,7 @@ const JK_V2_METADATA_KEY = Symbol.for("jk:v2:metadata")
 // metadata map keys
 export const JK_V2_METADATA_API_VIEW_KEY = Symbol.for("jk:v2:metadata:api:view")
 // sub-route method inside a class
-export const JK_V2_METADATA_SUBROUTES_KEY = Symbol.for("jk:v2:metadata:subroutes")
+export const JK_V2_METADATA_SUBROUTES_KEY = Symbol.for("jk:v2:metadata:subroutesuth")
 // standalone function
 export const JK_V2_METADATA_FUNCTION_KEY = Symbol.for("jk:v2:metadata:function")
 

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -4,7 +4,7 @@
 /**
  * Wrappers for getting/setting metadata on classes and class properties
  */
-import { HttpMethod } from "@aws-cdk/aws-apigatewayv2"
+import { HttpMethod, HttpRouteProps } from "@aws-cdk/aws-apigatewayv2"
 import { Schedule } from "@aws-cdk/aws-events"
 import "reflect-metadata"
 import { ApiHandler, ApiViewBase } from "./api/base"
@@ -34,7 +34,9 @@ export type MetadataTarget = PossibleLambdaHandlers | MetadataTargetConstructor
 /**
  * Metadata describing any Lambda function.
  */
-export interface IFunctionMetadataBase extends FunctionOptions {
+export interface IFunctionMetadataBase
+  extends FunctionOptions,
+    Pick<HttpRouteProps, "authorizationScopes" | "authorizer"> {
   /**
    * An optional API Gateway path to trigger this function.
    */

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -9,7 +9,7 @@ import { Schedule } from "@aws-cdk/aws-events"
 import "reflect-metadata"
 import { ApiHandler, ApiViewBase } from "./api/base"
 import { FunctionOptions } from "./cdk/generator"
-import { ApiViewOpts, PossibleLambdaHandlers } from "./registry"
+import { ApiViewOpts, IRoutePropsBase, PossibleLambdaHandlers } from "./registry"
 
 /**
  * A class we can apply @ApiView to.
@@ -33,19 +33,7 @@ export type MetadataTarget = PossibleLambdaHandlers | MetadataTargetConstructor
 /**
  * Metadata describing any Lambda function.
  */
-export interface IFunctionMetadataBase
-  extends FunctionOptions,
-    Pick<HttpRouteProps, "authorizationScopes" | "authorizer"> {
-  /**
-   * An optional API Gateway path to trigger this function.
-   */
-  path?: string
-
-  /**
-   * If `path` is defined, this determines which methods the path responds to.
-   */
-  methods?: HttpMethod[]
-
+export interface IFunctionMetadataBase extends FunctionOptions, Partial<IRoutePropsBase> {
   /**
    * Path to the file containing the handler.
    * Normally shouldn't need to be specified and can be guessed.
@@ -57,14 +45,6 @@ export interface IFunctionMetadataBase
    * Triggers a CloudWatch Event.
    */
   schedule?: Schedule
-
-  /**
-   * Disable default authorizer.
-   *
-   * Set to true for routes that do not require authentication
-   * if your routes normally require it.
-   */
-  unauthorized?: boolean
 }
 
 /**

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -58,7 +58,7 @@ interface RoutePropertyDescriptor extends PropertyDescriptor {
   value?: ApiHandler
 }
 
-export interface IRoutePropsBase extends Partial<HttpRouteProps> {
+export interface IRoutePropsBase extends Pick<HttpRouteProps, "authorizer" | "authorizationScopes"> {
   /**
    * An optional API Gateway path to trigger this function.
    *
@@ -75,7 +75,7 @@ export interface IRoutePropsBase extends Partial<HttpRouteProps> {
   /**
    * Disable default authorizer.
    *
-   * Set to true for routes that do not require authentication
+   * Set to true for routes that do not require authorization
    * if your routes normally require it.
    */
   unauthorized?: boolean

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -60,18 +60,24 @@ interface RoutePropertyDescriptor extends PropertyDescriptor {
 
 export interface IRoutePropsBase extends Partial<HttpRouteProps> {
   /**
-   * Route.
+   * An optional API Gateway path to trigger this function.
    *
    * e.g. "/v1/foo/bar"
    */
   path: string
 
   /**
-   * Enabled {@link HttpMethod}s for route
+   * Enabled {@link HttpMethod}s for route.
+   * If `path` is defined, this determines which methods the path responds to.
    */
   methods?: HttpMethod[]
 
-  // disable authorization?
+  /**
+   * Disable default authorizer.
+   *
+   * Set to true for routes that do not require authentication
+   * if your routes normally require it.
+   */
   unauthorized?: boolean
 }
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -32,7 +32,7 @@ import { findDefiningFile } from "./util/function"
  *
  * @category Metadata Decorator
  */
-export function ApiView(opts: IFunctionMetadataBase) {
+export function ApiView(opts: ApiViewOpts) {
   // try to guess the filename where this decorator is being applied
 
   if (!opts.entry) {

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -52,6 +52,7 @@ export function ApiView(opts: IFunctionMetadataBase) {
     return constructor
   }
 }
+export type ApiViewOpts = Omit<IFunctionMetadataBase, "methods">
 
 interface RoutePropertyDescriptor extends PropertyDescriptor {
   value?: ApiHandler
@@ -74,7 +75,10 @@ export interface IRoutePropsBase extends Partial<HttpRouteProps> {
   unauthorized?: boolean
 }
 
-export type ISubRouteProps = IRoutePropsBase
+export interface ISubRouteProps extends Omit<IRoutePropsBase, "path"> {
+  // make path optional in @SubRoute
+  path?: string
+}
 
 export interface IRouteProps extends FunctionOptions, IRoutePropsBase {}
 

--- a/src/test/sampleApp.ts
+++ b/src/test/sampleApp.ts
@@ -93,7 +93,12 @@ Lambda({
   unauthorized: true,
   path: "/unauthView",
 })
-export class UnAuthView extends ApiViewBase {}
+export class UnAuthView extends ApiViewBase {
+  @SubRoute({ methods: [HttpMethod.GET] })
+  async get() {
+    return "blorp"
+  }
+}
 
 // authenticated ApiView
 @ApiView({

--- a/src/test/sampleApp.ts
+++ b/src/test/sampleApp.ts
@@ -16,7 +16,10 @@ import { ApiView, Lambda, SubRoute } from "../registry"
 })
 export class AlbumApi extends ApiViewBase {
   // define POST handler
-  post = async () => "Created new album"
+  @SubRoute({ methods: [HttpMethod.POST] })
+  async post() {
+    return "Created new album"
+  }
 
   // custom endpoint in the view
   // routes to the ApiView function

--- a/src/test/sampleApp.ts
+++ b/src/test/sampleApp.ts
@@ -81,14 +81,14 @@ Lambda({
   schedule: Schedule.rate(Duration.minutes(10)),
 })(scheduledFunc)
 
-// unauthenticated route
-export const unauthFunc = () => console.log("does not require authentication")
+// unauthorized route
+export const unauthFunc = () => console.log("does not require authorization")
 Lambda({
   unauthorized: true,
-  path: "/unauthenticated",
+  path: "/unauthorized",
 })(unauthFunc)
 
-// unauthenticated ApiView
+// unauthorized ApiView
 @ApiView({
   unauthorized: true,
   path: "/unauthView",
@@ -100,16 +100,21 @@ export class UnAuthView extends ApiViewBase {
   }
 }
 
-// authenticated ApiView
+// authorized ApiView
 @ApiView({
   path: "/authView",
   authorizationScopes: ["charts:read"],
 })
-export class AuthScopeView extends ApiViewBase {}
+export class AuthScopeView extends ApiViewBase {
+  @SubRoute({ methods: [HttpMethod.GET] })
+  async get() {
+    return "blorp"
+  }
+}
 
-// authenticated func
-export const authFunc = () => console.log("requires authentication")
+// authorized func
+export const authFunc = () => console.log("requires authorization")
 Lambda({
   authorizationScopes: ["charts:write"],
-  path: "/authenticated",
+  path: "/authorized",
 })(authFunc)

--- a/src/test/sampleApp.ts
+++ b/src/test/sampleApp.ts
@@ -50,7 +50,6 @@ export async function topSongsHandler(event: ApiEvent) {
 Lambda({
   path: "/top-songs",
   methods: [HttpMethod.PUT],
-  authorizationScopes: ["charts:read"],
   memorySize: 384,
   environment: {
     LOG_LEVEL: "WARN",
@@ -92,3 +91,17 @@ Lambda({
   path: "/unauthView",
 })
 export class UnAuthView extends ApiViewBase {}
+
+// authenticated ApiView
+@ApiView({
+  path: "/authView",
+  authorizationScopes: ["charts:read"],
+})
+export class AuthScopeView extends ApiViewBase {}
+
+// authenticated func
+export const authFunc = () => console.log("requires authentication")
+Lambda({
+  authorizationScopes: ["charts:write"],
+  path: "/authenticated",
+})(authFunc)


### PR DESCRIPTION
I originally had an idea of having "magic" routing of view functions by HTTP verb. I.e.:

```ts
@ApiView({
  path: "/album",
  methods: [HttpMethod.POST],  // <-- optional but confusing
})
export class AlbumApi extends ApiViewBase {
  // define POST /album handler
  post = async () => "Created new album"

...

  // custom endpoint in the view
  // routes to the ApiView function
  @SubRoute({
    path: "/{albumId}/like", // will be /album/123/like
    methods: [HttpMethod.POST, HttpMethod.DELETE],
  })
  async like(event: ApiEvent): ApiResponse {
    const albumId = event.pathParameters?.albumId
    if (!albumId) throw badRequest("albumId is required in path")
    const method = event.requestContext.http.method
    // POST - mark album as liked
    if (method == HttpMethod.POST) return `Liked album ${albumId}`
    // DELETE - unmark album as liked
    else if (method == HttpMethod.DELETE) return `Unliked album ${albumId}`
    else return methodNotAllowed()
  }
}
```

I've realized that there are a few issues here:

1. The routing to methods named after verbs (post, get, put, etc) is rather magical and non-obvious. Verb methods don't need `@SubRoute` but all other methods do.
2. It's confusing what needs to be set for `methods` in the `@ApiView()` - easiest to leave this out so it matches all methods and then it checks what methods exist when a request come in. This ends up creating overly-broad routes on the `@ApiView`
3. Having a route created for the `@ApiView` itself and not the individual methods is weird.. why does a view class get a route?
4. No way to add other `@SubRoute` properties (e.g. `unauthorized`) to a magic verb method 

Solution is very simple: remove magic verb methods and the `methods` parameter for `@ApiView()`.

So now it looks like:
```ts
@ApiView({
  path: "/album",
})
export class AlbumApi extends ApiViewBase {
  // define POST handler
  @SubRoute({ methods: [HttpMethod.POST] })
  async post() {
    return "Created new album"
  }
}
```