### PR TITLE
Fix 'this' when dispatching API methods

### DIFF
--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -146,7 +146,6 @@ export class ApiViewBase {
       const handlerMethod = this.findHandler(event)
       if (handlerMethod) {
         // call handler
-        // TODO: might need to call `apply` here with this
         return await handlerMethod.call(this, event, context)
       } else {
         // 404

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -147,7 +147,7 @@ export class ApiViewBase {
       if (handlerMethod) {
         // call handler
         // TODO: might need to call `apply` here with this
-        return await handlerMethod(event, context)
+        return await handlerMethod.call(this, event, context)
       } else {
         // 404
         throw notFound(`The path ${method} ${path} was not found`)


### PR DESCRIPTION
Make it so we can actually use these class views as proper classes and call other methods