### PR TITLE
Add a name postfix for CfnOutput created by the ResourceGenerator class

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetkit/cdk",
-  "version": "1.115.31",
+  "version": "1.115.32",
   "description": "Cloud-native serverless anti-framework",
   "types": "build/esm/index.d.ts",
   "main": "build/cjs/index.js",

--- a/src/cdk/generator.test.ts
+++ b/src/cdk/generator.test.ts
@@ -8,7 +8,7 @@ import { Code, Function, FunctionOptions, Runtime } from "@aws-cdk/aws-lambda"
 import { NodejsFunction } from "@aws-cdk/aws-lambda-nodejs"
 import { Duration, Stack } from "@aws-cdk/core"
 import * as path from "path"
-import { ApiViewConstruct, ResourceGeneratorConstruct } from ".."
+import { ResourceGeneratorConstruct } from ".."
 import {
   AlbumApi,
   authFunc,

--- a/src/cdk/generator.test.ts
+++ b/src/cdk/generator.test.ts
@@ -168,36 +168,36 @@ describe("@SubRoute construct generation", () => {
       outputValue: "POST /album",
     })
     expect(stack).toHaveOutput({
+      exportName: {
+        "Fn::Join": [
+          "-",
+          [
+            {
+              Ref: "AWS::StackName",
+            },
+            httpApi.httpApiName
+          ],
+        ],
+      },
       outputValue: {
         "Fn::Join": [
           "",
           [
             "https://",
             {
-              "Ref": "API62EA1CFF"
+              Ref: "API62EA1CFF",
             },
             ".execute-api.",
             {
-              "Ref": "AWS::Region"
+              Ref: "AWS::Region",
             },
             ".",
             {
-              "Ref": "AWS::URLSuffix"
+              Ref: "AWS::URLSuffix",
             },
-            "/"
-          ]
-        ]
-      },
-      exportName: {
-        "Fn::Join": [
-          "-",
-          [
-            {
-              "Ref": "AWS::StackName"
-            },
-            httpApi.httpApiName
-          ]
-        ]
+            "/",
+          ],
+        ],
       },
     })
   })

--- a/src/cdk/generator.test.ts
+++ b/src/cdk/generator.test.ts
@@ -195,9 +195,7 @@ describe("@SubRoute construct generation", () => {
             {
               "Ref": "AWS::StackName"
             },
-            {
-              "Ref": "API62EA1CFF"
-            }
+            httpApi.httpApiName
           ]
         ]
       },

--- a/src/cdk/generator.test.ts
+++ b/src/cdk/generator.test.ts
@@ -168,7 +168,6 @@ describe("@SubRoute construct generation", () => {
       outputValue: "POST /album",
     })
     expect(stack).toHaveOutput({
-      outputName: "GenApiBase123427DCC3AB",
       outputValue: {
         "Fn::Join": [
           "",

--- a/src/cdk/generator.test.ts
+++ b/src/cdk/generator.test.ts
@@ -167,38 +167,40 @@ describe("@SubRoute construct generation", () => {
       outputName: "GenSRAlbumApipostRoute5F0E8C334",
       outputValue: "POST /album",
     })
-
     expect(stack).toHaveOutput({
-      exportName: {
-        "Fn::Join": [
-          "-",
-          [
-            {
-              Ref: "AWS::StackName",
-            },
-            "ApiBase",
-          ],
-        ],
-      },
+      outputName: "GenApiBase123427DCC3AB",
       outputValue: {
         "Fn::Join": [
           "",
           [
             "https://",
             {
-              Ref: "API62EA1CFF",
+              "Ref": "API62EA1CFF"
             },
             ".execute-api.",
             {
-              Ref: "AWS::Region",
+              "Ref": "AWS::Region"
             },
             ".",
             {
-              Ref: "AWS::URLSuffix",
+              "Ref": "AWS::URLSuffix"
             },
-            "/",
-          ],
-        ],
+            "/"
+          ]
+        ]
+      },
+      exportName: {
+        "Fn::Join": [
+          "-",
+          [
+            {
+              "Ref": "AWS::StackName"
+            },
+            {
+              "Ref": "API62EA1CFF"
+            }
+          ]
+        ]
       },
     })
   })

--- a/src/cdk/generator.ts
+++ b/src/cdk/generator.ts
@@ -133,8 +133,8 @@ export class ResourceGenerator extends Construct {
 
     // it's handy to have the API base URL as a stack output
     if (this.httpApi?.url) {
-      const apiName: string = this.httpApi.httpApiName || "ApiBase"
-      new CfnOutput(this, apiName, { value: this.httpApi.url, exportName: Fn.join("-", [Aws.STACK_NAME, apiName]) })
+      const apiName = this.httpApi.httpApiName
+      new CfnOutput(this, apiName, { value: this.httpApi.url, ...(apiName ? {exportName: Fn.join("-", [Aws.STACK_NAME, apiName]) : {}) })
     }
   }
 

--- a/src/cdk/generator.ts
+++ b/src/cdk/generator.ts
@@ -136,8 +136,10 @@ export class ResourceGenerator extends Construct {
     const outputName = `ApiBase${namePostfix}`
 
     // it's handy to have the API base URL as a stack output
-    if (this.httpApi?.url)
-      new CfnOutput(this, outputName, { value: this.httpApi.url, exportName: Fn.join("-", [Aws.STACK_NAME, this.httpApi.apiId]) })
+    if (this.httpApi?.url) {
+      const apiName: string = this.httpApi.httpApiName || outputName
+      new CfnOutput(this, outputName, { value: this.httpApi.url, exportName: Fn.join("-", [Aws.STACK_NAME, apiName]) })
+    }
   }
 
   generateConstructsForResource(resource: MetadataTarget) {

--- a/src/cdk/generator.ts
+++ b/src/cdk/generator.ts
@@ -137,7 +137,7 @@ export class ResourceGenerator extends Construct {
 
     // it's handy to have the API base URL as a stack output
     if (this.httpApi?.url)
-      new CfnOutput(this, outputName, { value: this.httpApi.url, exportName: Fn.join("-", [Aws.STACK_NAME, this.httpApi.apiName]) })
+      new CfnOutput(this, outputName, { value: this.httpApi.url, exportName: Fn.join("-", [Aws.STACK_NAME, this.httpApi.apiId]) })
   }
 
   generateConstructsForResource(resource: MetadataTarget) {

--- a/src/cdk/generator.ts
+++ b/src/cdk/generator.ts
@@ -15,6 +15,7 @@ import * as targets from "@aws-cdk/aws-events-targets"
 import { SlsPgDb } from "./database/serverless-pg"
 import { IVpc } from "@aws-cdk/aws-ec2"
 import { debug } from "../util/log"
+import { randomBetweenNAndM } from "../util/math"
 import { Node14Func, Node14FuncProps } from "./lambda/node14func"
 import { LambdaProxyIntegration } from "@aws-cdk/aws-apigatewayv2-integrations"
 import slugify from "slugify"
@@ -131,9 +132,12 @@ export class ResourceGenerator extends Construct {
     // emit CDK constructs for specified resources
     resources.forEach((resource) => this.generateConstructsForResource(resource))
 
+    const namePostfix = randomBetweenNAndM(1000, 2000)
+    const outputName = `ApiBase${namePostfix}`
+
     // it's handy to have the API base URL as a stack output
     if (this.httpApi?.url)
-      new CfnOutput(this, "ApiBase", { value: this.httpApi.url, exportName: Fn.join("-", [Aws.STACK_NAME, "ApiBase"]) })
+      new CfnOutput(this, outputName, { value: this.httpApi.url, exportName: Fn.join("-", [Aws.STACK_NAME, outputName]) })
   }
 
   generateConstructsForResource(resource: MetadataTarget) {

--- a/src/cdk/generator.ts
+++ b/src/cdk/generator.ts
@@ -137,7 +137,7 @@ export class ResourceGenerator extends Construct {
 
     // it's handy to have the API base URL as a stack output
     if (this.httpApi?.url)
-      new CfnOutput(this, outputName, { value: this.httpApi.url, exportName: Fn.join("-", [Aws.STACK_NAME, outputName]) })
+      new CfnOutput(this, outputName, { value: this.httpApi.url, exportName: Fn.join("-", [Aws.STACK_NAME, this.httpApi.apiName]) })
   }
 
   generateConstructsForResource(resource: MetadataTarget) {

--- a/src/cdk/generator.ts
+++ b/src/cdk/generator.ts
@@ -15,7 +15,6 @@ import * as targets from "@aws-cdk/aws-events-targets"
 import { SlsPgDb } from "./database/serverless-pg"
 import { IVpc } from "@aws-cdk/aws-ec2"
 import { debug } from "../util/log"
-import { randomBetweenNAndM } from "../util/math"
 import { Node14Func, Node14FuncProps } from "./lambda/node14func"
 import { LambdaProxyIntegration } from "@aws-cdk/aws-apigatewayv2-integrations"
 import slugify from "slugify"
@@ -132,13 +131,10 @@ export class ResourceGenerator extends Construct {
     // emit CDK constructs for specified resources
     resources.forEach((resource) => this.generateConstructsForResource(resource))
 
-    const namePostfix = randomBetweenNAndM(1000, 2000)
-    const outputName = `ApiBase${namePostfix}`
-
     // it's handy to have the API base URL as a stack output
     if (this.httpApi?.url) {
-      const apiName: string = this.httpApi.httpApiName || outputName
-      new CfnOutput(this, outputName, { value: this.httpApi.url, exportName: Fn.join("-", [Aws.STACK_NAME, apiName]) })
+      const apiName: string = this.httpApi.httpApiName || "ApiBase"
+      new CfnOutput(this, apiName, { value: this.httpApi.url, exportName: Fn.join("-", [Aws.STACK_NAME, apiName]) })
     }
   }
 

--- a/src/cdk/generator.ts
+++ b/src/cdk/generator.ts
@@ -133,8 +133,8 @@ export class ResourceGenerator extends Construct {
 
     // it's handy to have the API base URL as a stack output
     if (this.httpApi?.url) {
-      const apiName = this.httpApi.httpApiName
-      new CfnOutput(this, apiName, { value: this.httpApi.url, ...(apiName ? {exportName: Fn.join("-", [Aws.STACK_NAME, apiName]) : {}) })
+      const apiName = this.httpApi.httpApiName || "ApiBase"
+      new CfnOutput(this, apiName, { value: this.httpApi.url, ...(apiName ? {exportName: Fn.join("-", [Aws.STACK_NAME, apiName])} : {}) })
     }
   }
 

--- a/src/util/math.ts
+++ b/src/util/math.ts
@@ -1,8 +1,0 @@
-export function randomBetweenNAndM(n: number, m: number): number {
-  /**
-   * creates a random number between n and m, m not inclusive [n,m)
-   */
-  if (n > m) throw Error("m has to be equal or bigger than n")
-  const diff = m - n
-  return Math.floor(n + Math.floor(diff * Math.random()))
-}

--- a/src/util/math.ts
+++ b/src/util/math.ts
@@ -1,0 +1,8 @@
+export function randomBetweenNAndM(n: number, m: number): number {
+  /**
+   * creates a random number between n and m, m not inclusive [n,m)
+   */
+  if (n > m) throw Error("m has to be equal or bigger than n")
+  const diff = m - n
+  return Math.floor(n + Math.floor(diff * Math.random()))
+}


### PR DESCRIPTION
without the name postfix the class ResourceGenerator always had created a CfnOutput with the same name ApiBase leading to the error showed bellow, this PR simply adds a name postfix to avoid using the same name more than once

<img width="1792" alt="Screen Shot 2021-08-19 at 16 02 05" src="https://user-images.githubusercontent.com/58014752/130232672-ba31c41c-4135-4cc0-8dc4-fb646a8c73ec.png">
