### PR TITLE
Testing out not generating/bundling prisma client, only engines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jetkit/cdk",
-  "version": "1.122.19",
+  "version": "1.122.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@jetkit/cdk",
-      "version": "1.122.19",
+      "version": "1.122.20",
       "license": "MIT",
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2": "1.122.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jetkit/cdk",
-  "version": "1.122.20",
+  "version": "1.122.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@jetkit/cdk",
-      "version": "1.122.20",
+      "version": "1.122.21",
       "license": "MIT",
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2": "1.122.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetkit/cdk",
-  "version": "1.122.19",
+  "version": "1.122.20",
   "description": "Cloud-native serverless anti-framework",
   "types": "build/esm/index.d.ts",
   "main": "build/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetkit/cdk",
-  "version": "1.122.20",
+  "version": "1.122.21",
   "description": "Cloud-native serverless anti-framework",
   "types": "build/esm/index.d.ts",
   "main": "build/cjs/index.js",

--- a/src/cdk/lambda/prismaLayer.ts
+++ b/src/cdk/lambda/prismaLayer.ts
@@ -138,12 +138,14 @@ export class PrismaLayer extends LayerVersion {
         // remove generated client
         `rm -rf ${nm}/.prisma`,
         `rm -rf ${nm}/@prisma/client`, // can't find .prisma/client from layer
+        `ls ${nm}/prisma`,
         // don't need extra sets of engines
         `rm -f ${nm}/prisma/client/*{-,_}engine-*`,
-        `rm -f ${nm}/prisma/*{-,_}engine-*`,
+        `rm -f ${nm}/prisma/engines/*engine-*`,
         // remove unused engine files
         `rm -f ${nm}/@prisma/engines/prisma-fmt-*`,
         `rm -f ${nm}/@prisma/engines/introspection-engine-*`,
+        `rm -f ${nm}/prisma/query-engine-*`,
         // `rm -f ${nm}/@prisma/engines/migration-engine-*`,
         // remove macOS clients if present
         `rm -f ${nm}/prisma/*-darwin*`,

--- a/src/cdk/lambda/prismaLayer.ts
+++ b/src/cdk/lambda/prismaLayer.ts
@@ -140,7 +140,6 @@ export class PrismaLayer extends LayerVersion {
         // remove unused engine files
         `rm -f ${nm}/@prisma/engines/prisma-fmt-*`,
         `rm -f ${nm}/@prisma/engines/introspection-engine-*`,
-        `rm -f ${nm}/@prisma/engines/*-darwin*`,
         // `rm -f ${nm}/@prisma/engines/migration-engine-*`,
         // remove macOS clients if present
         `rm -f ${nm}/prisma/*-darwin*`,

--- a/src/cdk/lambda/script/database/migration.ts
+++ b/src/cdk/lambda/script/database/migration.ts
@@ -16,9 +16,9 @@ export type ScriptProps = DatabaseFuncProps
  *    functionName: `${id}-migrate`,
  *    prismaPath: 'path/to/prisma',
  *    bundling: {
- *      externalModules: appLayer.externalModules,
+ *      externalModules: prismaLayer.externalModules,
  *    },
- *    layers: [appLayer],
+ *    layers: [prismaLayer],
  * })
  * ```
  */
@@ -26,7 +26,7 @@ export class DatabaseMigrationScript extends PrismaNode14Func {
   constructor(
     scope: Construct,
     id: string,
-    { handler, depsLockFilePath, entry, timeout, bundling, memorySize = 512, ...props }: ScriptProps
+    { handler, depsLockFilePath, environment, entry, timeout, bundling, memorySize = 512, ...props }: ScriptProps
   ) {
     // by default this uses migration.script.ts
     entry ||= `${__dirname}/migration.script.js` // it will have been already compiled
@@ -40,8 +40,13 @@ export class DatabaseMigrationScript extends PrismaNode14Func {
     nodeModules ||= []
     nodeModules.push("@prisma/migrate", "@prisma/sdk")
 
+    environment ||= {}
+    environment.PRISMA_QUERY_ENGINE_LIBRARY =
+      "/opt/nodejs/node_modules/@prisma/engines/libquery_engine-rhel-openssl-1.0.x.so.node"
+
     super(scope, id, {
       ...props,
+      environment,
       entry,
       memorySize,
       depsLockFilePath,

--- a/src/cdk/lambda/script/database/migration.ts
+++ b/src/cdk/lambda/script/database/migration.ts
@@ -38,11 +38,11 @@ export class DatabaseMigrationScript extends PrismaNode14Func {
     // only works as actual files - can't be bundled
     // https://github.com/prisma/prisma/issues/8337#issuecomment-895380661
     nodeModules ||= []
-    nodeModules.push("@prisma/migrate", "@prisma/sdk")
+    nodeModules.push("@prisma/migrate", "@prisma/sdk", "prisma", ".prisma")
 
     environment ||= {}
-    environment.PRISMA_QUERY_ENGINE_LIBRARY =
-      "/opt/nodejs/node_modules/@prisma/engines/libquery_engine-rhel-openssl-1.0.x.so.node"
+    // environment.PRISMA_QUERY_ENGINE_LIBRARY =
+    // "/opt/nodejs/node_modules/prisma/libquery_engine-rhel-openssl-1.0.x.so.node"
 
     super(scope, id, {
       ...props,


### PR DESCRIPTION
It could speed up deployments where only the schema/client has changed. Instead of having to create a new prisma layer and update every function with it attached, we can bundle the generated prisma client in the lambda functions themselves that use it, resulting in faster deployments with less impact.

It will increase lambda bundle size though, by about 3.5MB for functions that use prisma (we have a handful). Hopefully this problem will mostly go away when [tree shaking is working](https://github.com/aws/aws-cdk/issues/13274).