### PR TITLE
Explicit return types for create lambda function calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13288,7 +13288,7 @@
     },
     "packages/cdk": {
       "name": "@jetkit/cdk",
-      "version": "2.0.10",
+      "version": "2.0.14",
       "license": "MIT",
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2": "*",
@@ -13377,7 +13377,7 @@
     },
     "packages/runtime": {
       "name": "@jetkit/cdk-runtime",
-      "version": "2.0.10",
+      "version": "2.0.14",
       "license": "MIT",
       "dependencies": {
         "reflect-metadata": "*"


### PR DESCRIPTION
Make return types of `generateConstructsForFunction` and `generateConstructsForClass` non-optional.

If you're calling them you expect a result or it to throw an exception.